### PR TITLE
refactor(sdk): update `WalletMultiSignature` interface

### DIFF
--- a/packages/sdk-ark/source/transaction.service.ts
+++ b/packages/sdk-ark/source/transaction.service.ts
@@ -126,8 +126,8 @@ export class TransactionService extends Services.AbstractTransactionService {
 			}
 
 			transaction.multiSignatureAsset({
-				publicKeys: data.mandatoryKeys,
-				min: data.numberOfSignatures,
+				publicKeys: data.publicKeys,
+				min: data.min,
 			});
 		});
 	}

--- a/packages/sdk-lsk/source/transaction-three.service.test.ts
+++ b/packages/sdk-lsk/source/transaction-three.service.test.ts
@@ -201,9 +201,8 @@ describe("TransactionService", () => {
 					}),
 				),
 				data: {
-					numberOfSignatures: 2,
-					mandatoryKeys: [wallet1.publicKey, wallet2.publicKey],
-					optionalKeys: [],
+					min: 2,
+					publicKeys: [wallet1.publicKey, wallet2.publicKey],
 				},
 			});
 

--- a/packages/sdk-lsk/source/transaction-three.service.ts
+++ b/packages/sdk-lsk/source/transaction-three.service.ts
@@ -69,9 +69,9 @@ export class TransactionService extends Services.AbstractTransactionService {
 		return this.#createFromData(
 			"keys:registerMultisignatureGroup",
 			{
-				numberOfSignatures: input.data.numberOfSignatures,
-				mandatoryKeys: convertStringList(input.data.mandatoryKeys),
-				optionalKeys: convertStringList(input.data.optionalKeys),
+				numberOfSignatures: input.data.publicKeys.length,
+				mandatoryKeys: convertStringList(input.data.publicKeys.slice(0, input.data.min)),
+				optionalKeys: convertStringList(input.data.publicKeys.slice(input.data.min)),
 			},
 			input,
 		);

--- a/packages/sdk/source/services/transaction.contract.ts
+++ b/packages/sdk/source/services/transaction.contract.ts
@@ -57,9 +57,9 @@ export interface VoteInput extends TransactionInput {
 export interface MultiSignatureInput extends TransactionInput {
 	data: {
 		lifetime?: number;
-		mandatoryKeys: string[];
-		numberOfSignatures: number;
-		optionalKeys: string[];
+		numberOfSignatures?: number;
+		min: number;
+		publicKeys: string[];
 		senderPublicKey?: string;
 	};
 }

--- a/packages/sdk/source/services/transaction.contract.ts
+++ b/packages/sdk/source/services/transaction.contract.ts
@@ -57,7 +57,6 @@ export interface VoteInput extends TransactionInput {
 export interface MultiSignatureInput extends TransactionInput {
 	data: {
 		lifetime?: number;
-		numberOfSignatures?: number;
 		min: number;
 		publicKeys: string[];
 		senderPublicKey?: string;


### PR DESCRIPTION
Reverting some changes because lisk is the exception to how multi-signatures generally work. Instead of changing the interface it'll be expected that the first N keys **(min)** are mandatory and that the remaining keys are optional. This leaves the interface intact and lets the coin itself figure out what to do with the keys.