### PR TITLE
refactor(sdk): add `multiSignature` property for signatories

### DIFF
--- a/packages/sdk-ada/source/client.service.test.ts
+++ b/packages/sdk-ada/source/client.service.test.ts
@@ -163,6 +163,7 @@ describe("ClientService", () => {
 
 			const txService = createService(TransactionService, undefined, (container) => {
 				container.constant(IoC.BindingType.Container, container);
+				container.singleton(IoC.BindingType.ClientService, ClientService);
 				container.constant(IoC.BindingType.DataTransferObjects, DataTransferObjects);
 				container.singleton(
 					IoC.BindingType.DataTransferObjectService,

--- a/packages/sdk-ada/source/client.service.ts
+++ b/packages/sdk-ada/source/client.service.ts
@@ -1,6 +1,5 @@
 import { Collections, Contracts, Exceptions, IoC, Services } from "@payvo/sdk";
 
-import { WalletData } from "./wallet.dto";
 import { fetchTransaction, fetchTransactions, fetchUtxosAggregate, submitTransaction } from "./graphql-helpers";
 import { usedAddressesForAccount } from "./transaction.domain";
 

--- a/packages/sdk-ada/source/transaction.service.test.ts
+++ b/packages/sdk-ada/source/transaction.service.test.ts
@@ -7,6 +7,7 @@ import { createService } from "../test/mocking";
 import { SignedTransactionData } from "./signed-transaction.dto";
 import { DataTransferObjects } from "./coin.dtos";
 import { AddressService } from "./address.service";
+import { ClientService } from "./client.service";
 import { KeyPairService } from "./key-pair.service";
 import { PublicKeyService } from "./public-key.service";
 import { TransactionService } from "./transaction.service";
@@ -17,6 +18,7 @@ beforeAll(async () => {
 	subject = createService(TransactionService, undefined, (container) => {
 		container.constant(IoC.BindingType.Container, container);
 		container.singleton(IoC.BindingType.AddressService, AddressService);
+		container.singleton(IoC.BindingType.ClientService, ClientService);
 		container.constant(IoC.BindingType.DataTransferObjects, DataTransferObjects);
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);

--- a/packages/sdk-ark/test/fixtures/client/DKkBL5Mg9v1TPcKQrcUuW1VQrVFu8bh82Q.json
+++ b/packages/sdk-ark/test/fixtures/client/DKkBL5Mg9v1TPcKQrcUuW1VQrVFu8bh82Q.json
@@ -1,0 +1,21 @@
+{
+	"data": {
+		"address": "DKkBL5Mg9v1TPcKQrcUuW1VQrVFu8bh82Q",
+		"publicKey": "03eafc966e4669f460fa063f3dfcd1a15689bb7515f8c66a0a9e137b9c28c64906",
+		"balance": "457474444828",
+		"nonce": "3",
+		"attributes": {
+			"multiSignature": {
+				"publicKeys": [
+					"0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+					"023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+					"032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+					"0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+					"029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+					"034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea"
+				],
+				"min": 4
+			}
+		}
+	}
+}

--- a/packages/sdk-atom/source/transaction.service.ts
+++ b/packages/sdk-atom/source/transaction.service.ts
@@ -5,9 +5,6 @@ import { createSignedTransactionData } from "./crypto";
 
 @IoC.injectable()
 export class TransactionService extends Services.AbstractTransactionService {
-	@IoC.inject(IoC.BindingType.ClientService)
-	protected readonly clientService!: Services.ClientService;
-
 	@IoC.inject(IoC.BindingType.AddressService)
 	protected readonly addressService!: Services.AddressService;
 

--- a/packages/sdk-lsk/source/transaction-three.service.ts
+++ b/packages/sdk-lsk/source/transaction-three.service.ts
@@ -8,9 +8,6 @@ import { AssetSerializer } from "./asset.serializer";
 
 @IoC.injectable()
 export class TransactionService extends Services.AbstractTransactionService {
-	@IoC.inject(IoC.BindingType.ClientService)
-	private readonly clientService!: Services.ClientService;
-
 	@IoC.inject(IoC.BindingType.MultiSignatureService)
 	private readonly multiSignatureService!: Services.MultiSignatureService;
 

--- a/packages/sdk-nano/source/transaction.service.test.ts
+++ b/packages/sdk-nano/source/transaction.service.test.ts
@@ -8,6 +8,7 @@ import { createService } from "../test/mocking";
 import { DataTransferObjects } from "./coin.dtos";
 import { SignedTransactionData } from "./signed-transaction.dto";
 import { AddressService } from "./address.service";
+import { ClientService } from "./client.service";
 import { KeyPairService } from "./key-pair.service";
 import { PublicKeyService } from "./public-key.service";
 import { TransactionService } from "./transaction.service";
@@ -18,6 +19,7 @@ beforeAll(async () => {
 	subject = createService(TransactionService, undefined, (container) => {
 		container.constant(IoC.BindingType.Container, container);
 		container.singleton(IoC.BindingType.AddressService, AddressService);
+		container.singleton(IoC.BindingType.ClientService, ClientService);
 		container.constant(IoC.BindingType.DataTransferObjects, DataTransferObjects);
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);

--- a/packages/sdk-trx/source/transaction.service.test.ts
+++ b/packages/sdk-trx/source/transaction.service.test.ts
@@ -7,6 +7,7 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { DataTransferObjects } from "./coin.dtos";
 import { AddressService } from "./address.service";
+import { ClientService } from "./client.service";
 import { KeyPairService } from "./key-pair.service";
 import { PrivateKeyService } from "./private-key.service";
 import { PublicKeyService } from "./public-key.service";
@@ -18,6 +19,7 @@ beforeAll(async () => {
 	subject = createService(TransactionService, undefined, (container) => {
 		container.constant(IoC.BindingType.Container, container);
 		container.singleton(IoC.BindingType.AddressService, AddressService);
+		container.singleton(IoC.BindingType.ClientService, ClientService);
 		container.constant(IoC.BindingType.DataTransferObjects, DataTransferObjects);
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);

--- a/packages/sdk-xlm/source/client.service.test.ts
+++ b/packages/sdk-xlm/source/client.service.test.ts
@@ -118,6 +118,7 @@ describe("ClientService", () => {
 
 			const transactionService = createService(TransactionService, undefined, (container: IoC.Container) => {
 				container.constant(IoC.BindingType.Container, container);
+				container.singleton(IoC.BindingType.ClientService, ClientService);
 				container.constant(IoC.BindingType.DataTransferObjects, DataTransferObjects);
 				container.singleton(
 					IoC.BindingType.DataTransferObjectService,
@@ -163,6 +164,7 @@ describe("ClientService", () => {
 
 			const transactionService = createService(TransactionService, undefined, (container: IoC.Container) => {
 				container.constant(IoC.BindingType.Container, container);
+				container.singleton(IoC.BindingType.ClientService, ClientService);
 				container.constant(IoC.BindingType.DataTransferObjects, DataTransferObjects);
 				container.singleton(
 					IoC.BindingType.DataTransferObjectService,

--- a/packages/sdk-xlm/source/transaction.service.test.ts
+++ b/packages/sdk-xlm/source/transaction.service.test.ts
@@ -7,6 +7,7 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { DataTransferObjects } from "./coin.dtos";
 import { AddressService } from "./address.service";
+import { ClientService } from "./client.service";
 import { KeyPairService } from "./key-pair.service";
 import { PublicKeyService } from "./public-key.service";
 import { TransactionService } from "./transaction.service";
@@ -17,6 +18,7 @@ beforeAll(async () => {
 	subject = createService(TransactionService, undefined, (container) => {
 		container.constant(IoC.BindingType.Container, container);
 		container.singleton(IoC.BindingType.AddressService, AddressService);
+		container.singleton(IoC.BindingType.ClientService, ClientService);
 		container.constant(IoC.BindingType.DataTransferObjects, DataTransferObjects);
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);

--- a/packages/sdk-zil/source/transaction.service.test.ts
+++ b/packages/sdk-zil/source/transaction.service.test.ts
@@ -7,6 +7,7 @@ import { createService } from "../test/mocking";
 import { DataTransferObjects } from "./coin.dtos";
 import { SignedTransactionData } from "./signed-transaction.dto";
 import { AddressService } from "./address.service";
+import { ClientService } from "./client.service";
 import { KeyPairService } from "./key-pair.service";
 import { PublicKeyService } from "./public-key.service";
 import { TransactionService } from "./transaction.service";
@@ -17,6 +18,7 @@ beforeAll(async () => {
 	subject = createService(TransactionService, undefined, (container) => {
 		container.constant(IoC.BindingType.Container, container);
 		container.singleton(IoC.BindingType.AddressService, AddressService);
+		container.singleton(IoC.BindingType.ClientService, ClientService);
 		container.constant(IoC.BindingType.DataTransferObjects, DataTransferObjects);
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);

--- a/packages/sdk/source/services/multi-signature.contract.ts
+++ b/packages/sdk/source/services/multi-signature.contract.ts
@@ -4,6 +4,11 @@ import { BroadcastResponse } from "./client.contract";
 
 export type MultiSignatureTransaction = Record<string, any>;
 
+export interface MultiSignatureAsset {
+	publicKeys: string[];
+	min: number;
+}
+
 /**
  * A service to manage, sign and broadcast all multi-signature transactions.
  *

--- a/packages/sdk/source/services/shared.contract.ts
+++ b/packages/sdk/source/services/shared.contract.ts
@@ -1,3 +1,5 @@
+import { MultiSignatureAsset } from "./multi-signature.contract";
+
 export interface IdentityOptions {
 	bip39?: boolean;
 	bip44?: {
@@ -15,4 +17,5 @@ export interface IdentityOptions {
 		change?: number;
 		addressIndex?: number;
 	};
+	multiSignature?: MultiSignatureAsset;
 }

--- a/packages/sdk/source/services/signatory.service.ts
+++ b/packages/sdk/source/services/signatory.service.ts
@@ -52,6 +52,7 @@ export class AbstractSignatoryService implements SignatoryService {
 				publicKey: (await this.publicKeyService.fromMnemonic(mnemonic, options)).publicKey,
 				privateKey: (await this.privateKeyService.fromMnemonic(mnemonic, options)).privateKey,
 			}),
+			options?.multiSignature,
 		);
 	}
 
@@ -68,10 +69,11 @@ export class AbstractSignatoryService implements SignatoryService {
 				publicKey: (await this.publicKeyService.fromMnemonic(signingKey, options)).publicKey,
 				privateKey: (await this.privateKeyService.fromMnemonic(signingKey, options)).privateKey,
 			}),
+			options?.multiSignature,
 		);
 	}
 
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatory> {
+	public async multiMnemonic(mnemonics: string[], options?: IdentityOptions): Promise<Signatory> {
 		return new Signatory(
 			new MultiMnemonicSignatory(
 				mnemonics,
@@ -79,10 +81,11 @@ export class AbstractSignatoryService implements SignatoryService {
 					await Promise.all(mnemonics.map((mnemonic: string) => this.publicKeyService.fromMnemonic(mnemonic)))
 				).map(({ publicKey }) => publicKey),
 			),
+			options?.multiSignature,
 		);
 	}
 
-	public async wif(primary: string): Promise<Signatory> {
+	public async wif(primary: string, options?: IdentityOptions): Promise<Signatory> {
 		return new Signatory(
 			new WIFSignatory({
 				signingKey: primary,
@@ -90,10 +93,11 @@ export class AbstractSignatoryService implements SignatoryService {
 				publicKey: (await this.publicKeyService.fromWIF(primary)).publicKey,
 				privateKey: (await this.privateKeyService.fromWIF(primary)).privateKey,
 			}),
+			options?.multiSignature,
 		);
 	}
 
-	public async secondaryWif(signingKey: string, confirmKey: string): Promise<Signatory> {
+	public async secondaryWif(signingKey: string, confirmKey: string, options?: IdentityOptions): Promise<Signatory> {
 		return new Signatory(
 			new SecondaryWIFSignatory({
 				signingKey,
@@ -102,6 +106,7 @@ export class AbstractSignatoryService implements SignatoryService {
 				publicKey: (await this.publicKeyService.fromWIF(signingKey)).publicKey,
 				privateKey: (await this.privateKeyService.fromWIF(signingKey)).privateKey,
 			}),
+			options?.multiSignature,
 		);
 	}
 
@@ -111,6 +116,7 @@ export class AbstractSignatoryService implements SignatoryService {
 				signingKey: privateKey,
 				address: (await this.addressService.fromPrivateKey(privateKey, options)).address,
 			}),
+			options?.multiSignature,
 		);
 	}
 
@@ -121,6 +127,7 @@ export class AbstractSignatoryService implements SignatoryService {
 				address: (await this.addressService.fromPublicKey(publicKey, options)).address,
 				publicKey,
 			}),
+			options?.multiSignature,
 		);
 	}
 
@@ -130,14 +137,15 @@ export class AbstractSignatoryService implements SignatoryService {
 				{ min, publicKeys },
 				(await this.addressService.fromMultiSignature(min, publicKeys)).address,
 			),
+			options?.multiSignature ?? { min, publicKeys },
 		);
 	}
 
-	public async ledger(path: string): Promise<Signatory> {
-		return new Signatory(new LedgerSignatory(path));
+	public async ledger(path: string, options?: IdentityOptions): Promise<Signatory> {
+		return new Signatory(new LedgerSignatory(path), options?.multiSignature);
 	}
 
-	public async secret(secret: string): Promise<Signatory> {
+	public async secret(secret: string, options?: IdentityOptions): Promise<Signatory> {
 		return new Signatory(
 			new SecretSignatory({
 				signingKey: secret,
@@ -145,6 +153,7 @@ export class AbstractSignatoryService implements SignatoryService {
 				publicKey: (await this.publicKeyService.fromSecret(secret)).publicKey,
 				privateKey: (await this.privateKeyService.fromSecret(secret)).privateKey,
 			}),
+			options?.multiSignature,
 		);
 	}
 }

--- a/packages/sdk/source/services/transaction.service.ts
+++ b/packages/sdk/source/services/transaction.service.ts
@@ -9,6 +9,7 @@ import { HttpClient } from "../http";
 import { inject, injectable } from "../ioc";
 import { BindingType } from "../ioc/service-provider.contract";
 import { BigNumberService } from "./big-number.service";
+import { ClientService } from "./client.contract";
 import { DataTransferObjectService } from "./data-transfer-object.contract";
 import {
 	DelegateRegistrationInput,
@@ -27,6 +28,9 @@ import {
 
 @injectable()
 export class AbstractTransactionService implements Contract {
+	@inject(BindingType.ClientService)
+	protected readonly clientService!: ClientService;
+
 	@inject(BindingType.ConfigRepository)
 	protected readonly configRepository!: ConfigRepository;
 

--- a/packages/sdk/source/signatories/multi-signature.ts
+++ b/packages/sdk/source/signatories/multi-signature.ts
@@ -1,18 +1,15 @@
-export interface MultiSignature {
-	publicKeys: string[];
-	min: number;
-}
+import { MultiSignatureAsset } from "../services";
 
 export class MultiSignatureSignatory {
-	readonly #signature: MultiSignature;
+	readonly #signature: MultiSignatureAsset;
 	readonly #identifier: string | undefined;
 
-	public constructor(signature: MultiSignature, identifier?: string) {
+	public constructor(signature: MultiSignatureAsset, identifier?: string) {
 		this.#signature = signature;
 		this.#identifier = identifier;
 	}
 
-	public signingList(): MultiSignature {
+	public signingList(): MultiSignatureAsset {
 		return this.#signature;
 	}
 

--- a/packages/sdk/source/signatories/signatory.test.ts
+++ b/packages/sdk/source/signatories/signatory.test.ts
@@ -129,6 +129,42 @@ describe("MnemonicSignatory", () => {
 
 		expect(subject.privateKey()).toMatchInlineSnapshot(`"privateKey"`);
 	});
+
+	test("#multiSignature", () => {
+		const subject = new Signatory(
+			new MnemonicSignatory({
+				signingKey: "signingKey",
+				address: "address",
+				publicKey: "publicKey",
+				privateKey: "privateKey",
+			}),
+			{
+				publicKeys: [
+					"0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+					"023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+					"032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+					"0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+					"029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+					"034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+				],
+				min: 4,
+			},
+		);
+
+		expect(subject.multiSignature()).toMatchInlineSnapshot(`
+		Object {
+		  "min": 4,
+		  "publicKeys": Array [
+		    "0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+		    "023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+		    "032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+		    "0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+		    "029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+		    "034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+		  ],
+		}
+	`);
+	});
 });
 
 describe("MultiMnemonicSignatory", () => {
@@ -192,6 +228,34 @@ describe("MultiMnemonicSignatory", () => {
 		const subject = new Signatory(new MultiMnemonicSignatory(["signingKey"], ["identifier"]));
 
 		expect(() => subject.privateKey()).toThrow(/cannot be called/);
+	});
+
+	test("#multiSignature", () => {
+		const subject = new Signatory(new MultiMnemonicSignatory(["signingKey"], ["identifier"]), {
+			publicKeys: [
+				"0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+				"023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+				"032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+				"0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+				"029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+				"034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+			],
+			min: 4,
+		});
+
+		expect(subject.multiSignature()).toMatchInlineSnapshot(`
+		Object {
+		  "min": 4,
+		  "publicKeys": Array [
+		    "0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+		    "023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+		    "032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+		    "0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+		    "029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+		    "034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+		  ],
+		}
+	`);
 	});
 });
 
@@ -321,6 +385,43 @@ describe("SecondaryMnemonicSignatory", () => {
 
 		expect(subject.privateKey()).toMatchInlineSnapshot(`"privateKey"`);
 	});
+
+	test("#multiSignature", () => {
+		const subject = new Signatory(
+			new SecondaryMnemonicSignatory({
+				signingKey: "signingKey",
+				confirmKey: "confirmKey",
+				address: "address",
+				publicKey: "publicKey",
+				privateKey: "privateKey",
+			}),
+			{
+				publicKeys: [
+					"0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+					"023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+					"032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+					"0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+					"029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+					"034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+				],
+				min: 4,
+			},
+		);
+
+		expect(subject.multiSignature()).toMatchInlineSnapshot(`
+		Object {
+		  "min": 4,
+		  "publicKeys": Array [
+		    "0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+		    "023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+		    "032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+		    "0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+		    "029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+		    "034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+		  ],
+		}
+	`);
+	});
 });
 
 describe("WIFSignatory", () => {
@@ -439,6 +540,42 @@ describe("WIFSignatory", () => {
 		);
 
 		expect(subject.privateKey()).toMatchInlineSnapshot(`"privateKey"`);
+	});
+
+	test("#multiSignature", () => {
+		const subject = new Signatory(
+			new WIFSignatory({
+				signingKey: "signingKey",
+				address: "address",
+				publicKey: "publicKey",
+				privateKey: "privateKey",
+			}),
+			{
+				publicKeys: [
+					"0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+					"023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+					"032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+					"0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+					"029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+					"034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+				],
+				min: 4,
+			},
+		);
+
+		expect(subject.multiSignature()).toMatchInlineSnapshot(`
+		Object {
+		  "min": 4,
+		  "publicKeys": Array [
+		    "0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+		    "023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+		    "032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+		    "0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+		    "029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+		    "034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+		  ],
+		}
+	`);
 	});
 });
 
@@ -568,6 +705,43 @@ describe("SecondaryWIFSignatory", () => {
 
 		expect(subject.privateKey()).toMatchInlineSnapshot(`"privateKey"`);
 	});
+
+	test("#multiSignature", () => {
+		const subject = new Signatory(
+			new SecondaryWIFSignatory({
+				signingKey: "signingKey",
+				confirmKey: "confirmKey",
+				address: "address",
+				publicKey: "publicKey",
+				privateKey: "privateKey",
+			}),
+			{
+				publicKeys: [
+					"0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+					"023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+					"032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+					"0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+					"029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+					"034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+				],
+				min: 4,
+			},
+		);
+
+		expect(subject.multiSignature()).toMatchInlineSnapshot(`
+		Object {
+		  "min": 4,
+		  "publicKeys": Array [
+		    "0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+		    "023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+		    "032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+		    "0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+		    "029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+		    "034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+		  ],
+		}
+	`);
+	});
 });
 
 describe("PrivateKeySignatory", () => {
@@ -668,6 +842,40 @@ describe("PrivateKeySignatory", () => {
 		);
 
 		expect(subject.privateKey()).toMatchInlineSnapshot(`"signingKey"`);
+	});
+
+	test("#multiSignature", () => {
+		const subject = new Signatory(
+			new PrivateKeySignatory({
+				signingKey: "signingKey",
+				address: "address",
+			}),
+			{
+				publicKeys: [
+					"0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+					"023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+					"032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+					"0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+					"029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+					"034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+				],
+				min: 4,
+			},
+		);
+
+		expect(subject.multiSignature()).toMatchInlineSnapshot(`
+		Object {
+		  "min": 4,
+		  "publicKeys": Array [
+		    "0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+		    "023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+		    "032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+		    "0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+		    "029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+		    "034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+		  ],
+		}
+	`);
 	});
 });
 
@@ -778,6 +986,41 @@ describe("SenderPublicKeySignatory", () => {
 		);
 
 		expect(() => subject.privateKey()).toThrow(/cannot be called/);
+	});
+
+	test("#multiSignature", () => {
+		const subject = new Signatory(
+			new SenderPublicKeySignatory({
+				signingKey: "signingKey",
+				address: "address",
+				publicKey: "publicKey",
+			}),
+			{
+				publicKeys: [
+					"0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+					"023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+					"032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+					"0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+					"029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+					"034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+				],
+				min: 4,
+			},
+		);
+
+		expect(subject.multiSignature()).toMatchInlineSnapshot(`
+		Object {
+		  "min": 4,
+		  "publicKeys": Array [
+		    "0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+		    "023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+		    "032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+		    "0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+		    "029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+		    "034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+		  ],
+		}
+	`);
 	});
 });
 
@@ -966,6 +1209,71 @@ describe("PrivateMultiSignatureSignatory", () => {
 
 		expect(() => subject.privateKey()).toThrow(/cannot be called/);
 	});
+
+	test("#multiSignature", () => {
+		const subject = new Signatory(
+			new PrivateMultiSignatureSignatory("this is a top secret passphrase 1", [
+				"this is a top secret passphrase 1",
+				"this is a top secret passphrase 2",
+			]),
+			{
+				publicKeys: [
+					"0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+					"023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+					"032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+					"0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+					"029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+					"034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+				],
+				min: 4,
+			},
+		);
+
+		expect(subject.multiSignature()).toMatchInlineSnapshot(`
+		Object {
+		  "min": 4,
+		  "publicKeys": Array [
+		    "0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+		    "023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+		    "032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+		    "0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+		    "029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+		    "034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+		  ],
+		}
+	`);
+	});
+});
+
+test("#hasMultiSignature", () => {
+	let subject = new Signatory(
+		new PrivateMultiSignatureSignatory("this is a top secret passphrase 1", [
+			"this is a top secret passphrase 1",
+			"this is a top secret passphrase 2",
+		]),
+	);
+
+	expect(subject.hasMultiSignature()).toBeBoolean();
+
+	subject = new Signatory(
+		new PrivateMultiSignatureSignatory("this is a top secret passphrase 1", [
+			"this is a top secret passphrase 1",
+			"this is a top secret passphrase 2",
+		]),
+		{
+			publicKeys: [
+				"0271e4ffe50f2955fe32f9e05fb29a23f7dfcce77fa4c8a76328c7ab735033f851",
+				"023197268b110ca9c695f181d43a159ce380902ec549fe641e8bda047da0daf989",
+				"032b0c8dccc71dde04bfc1281d3a35428a48acf0b72be9a3914d4ebca1d5a73c32",
+				"0380c64e07942aee235387b4cbdc00923f7f486b4f5051bef806e0514e93222dc5",
+				"029e4dac4887b1b5d764b877559ad5171932f75e4fdefcb9ee3a96adb78d254bc4",
+				"034996d0a7b9788386b9d8d6ae86af0a0d676aee657c69b3e506648c69e39c15ea",
+			],
+			min: 4,
+		},
+	);
+
+	expect(subject.hasMultiSignature()).toBeTrue();
 });
 
 test("#actsWithMnemonic", () => {

--- a/packages/sdk/source/signatories/signatory.ts
+++ b/packages/sdk/source/signatories/signatory.ts
@@ -1,13 +1,14 @@
 /* istanbul ignore file */
 
 import { ForbiddenMethodCallException } from "../exceptions";
+import { MultiSignatureAsset } from "../services";
 import { AbstractDoubleSignatory } from "./abstract-double-signatory";
 import { AbstractSignatory } from "./abstract-signatory";
 import { AbstractValueSignatory } from "./abstract-value-signatory";
 import { LedgerSignatory } from "./ledger";
 import { MnemonicSignatory } from "./mnemonic";
 import { MultiMnemonicSignatory } from "./multi-mnemonic";
-import { MultiSignature, MultiSignatureSignatory } from "./multi-signature";
+import { MultiSignatureSignatory } from "./multi-signature";
 import { PrivateKeySignatory } from "./private-key";
 import { PrivateMultiSignatureSignatory } from "./private-multi-signature";
 import { SecondaryMnemonicSignatory } from "./secondary-mnemonic";
@@ -31,9 +32,11 @@ type SignatoryType =
 
 export class Signatory {
 	readonly #signatory: SignatoryType;
+	readonly #multiSignature: MultiSignatureAsset | undefined;
 
-	public constructor(signatory: SignatoryType) {
+	public constructor(signatory: SignatoryType, multiSignature?: MultiSignatureAsset) {
 		this.#signatory = signatory;
+		this.#multiSignature = multiSignature;
 	}
 
 	public signingKey(): string {
@@ -62,7 +65,7 @@ export class Signatory {
 		throw new ForbiddenMethodCallException(this.constructor.name, this.signingKeys.name);
 	}
 
-	public signingList(): MultiSignature {
+	public signingList(): MultiSignatureAsset {
 		if (this.#signatory instanceof MultiSignatureSignatory) {
 			return this.#signatory.signingList();
 		}
@@ -160,6 +163,14 @@ export class Signatory {
 		}
 
 		throw new ForbiddenMethodCallException(this.constructor.name, this.path.name);
+	}
+
+	public multiSignature(): MultiSignatureAsset | undefined {
+		return this.#multiSignature;
+	}
+
+	public hasMultiSignature(): boolean {
+		return this.#multiSignature !== undefined;
 	}
 
 	public actsWithMnemonic(): boolean {


### PR DESCRIPTION
Some adjustments to sign multi-signature transactions before broadcasting them.