### PR TITLE
chore(ark): remove IPFS transaction for Compendia networks

### DIFF
--- a/packages/sdk-ark/source/networks/bind.mainnet.ts
+++ b/packages/sdk-ark/source/networks/bind.mainnet.ts
@@ -49,8 +49,6 @@ const network: Networks.NetworkManifest = {
 			"delegateRegistration",
 			"delegateResignation",
 			"estimateExpiration",
-			"ipfs.musig",
-			"ipfs",
 			"multiPayment.musig",
 			"multiPayment",
 			"multiSignature.musig",

--- a/packages/sdk/source/networks/network-repository.test.ts
+++ b/packages/sdk/source/networks/network-repository.test.ts
@@ -421,8 +421,6 @@ test("#all", () => {
 		        "delegateRegistration",
 		        "delegateResignation",
 		        "estimateExpiration",
-		        "ipfs.musig",
-		        "ipfs",
 		        "multiPayment.musig",
 		        "multiPayment",
 		        "multiSignature.musig",


### PR DESCRIPTION
https://app.clickup.com/t/1c20drh

I've seen [the latest PR](https://github.com/PayvoHQ/sdk/pull/139), but there's no mention in the task that it is only for dev/test network
If so, ignore this PR