### PR TITLE
fix(ark): handle vote when is not inside the `attributes` property

### DIFF
--- a/packages/sdk-ark/source/client.service.test.ts
+++ b/packages/sdk-ark/source/client.service.test.ts
@@ -236,6 +236,7 @@ describe("ClientService", () => {
 						...fixture.data.attributes,
 						vote: undefined,
 					},
+					vote: undefined,
 				},
 			};
 

--- a/packages/sdk-ark/source/client.service.test.ts
+++ b/packages/sdk-ark/source/client.service.test.ts
@@ -249,6 +249,25 @@ describe("ClientService", () => {
 			expect(result.votes).toMatchInlineSnapshot(`Array []`);
 		});
 
+		it("should succeed without attributes when no vote", async () => {
+			const fixtureWithoutVote = {
+				data: {
+					...fixture.data,
+					attributes: undefined,
+					vote: undefined,
+				}
+			};
+
+			nock(/.+/).get("/api/wallets/arkx").reply(200, fixtureWithoutVote);
+
+			const result = await subject.votes("arkx");
+
+			expect(result).toBeObject();
+			expect(result.used).toBe(0);
+			expect(result.available).toBe(1);
+			expect(result.votes).toMatchInlineSnapshot(`Array []`);
+		});
+
 		it("should succeed without attributes", async () => {
 			const fixtureWithoutVote = {
 				data: {
@@ -262,9 +281,16 @@ describe("ClientService", () => {
 			const result = await subject.votes("arkx");
 
 			expect(result).toBeObject();
-			expect(result.used).toBe(0);
-			expect(result.available).toBe(1);
-			expect(result.votes).toMatchInlineSnapshot(`Array []`);
+			expect(result.used).toBe(1);
+			expect(result.available).toBe(0);
+			expect(result.votes).toMatchInlineSnapshot(`
+			Array [
+			  Object {
+			    "amount": 0,
+			    "id": "03bbfb43ecb5a54a1e227bb37b5812b5321213838d376e2b455b6af78442621dec",
+			  },
+			]
+		`)
 		});
 	});
 

--- a/packages/sdk-ark/source/client.service.test.ts
+++ b/packages/sdk-ark/source/client.service.test.ts
@@ -256,7 +256,7 @@ describe("ClientService", () => {
 					...fixture.data,
 					attributes: undefined,
 					vote: undefined,
-				}
+				},
 			};
 
 			nock(/.+/).get("/api/wallets/arkx").reply(200, fixtureWithoutVote);
@@ -291,7 +291,7 @@ describe("ClientService", () => {
 			    "id": "03bbfb43ecb5a54a1e227bb37b5812b5321213838d376e2b455b6af78442621dec",
 			  },
 			]
-		`)
+		`);
 		});
 	});
 

--- a/packages/sdk-ark/source/client.service.ts
+++ b/packages/sdk-ark/source/client.service.ts
@@ -57,7 +57,8 @@ export class ClientService extends Services.AbstractClientService {
 	public override async votes(id: string): Promise<Services.VoteReport> {
 		const { data } = await this.#get(`wallets/${id}`);
 
-		const hasVoted = data.attributes?.vote !== undefined;
+		const vote = data.vote || data.attributes?.vote;
+		const hasVoted = vote !== undefined;
 
 		return {
 			used: hasVoted ? 1 : 0,
@@ -65,7 +66,7 @@ export class ClientService extends Services.AbstractClientService {
 			votes: hasVoted
 				? [
 						{
-							id: data.attributes?.vote,
+							id: vote,
 							amount: 0,
 						},
 				  ]


### PR DESCRIPTION
Related to: https://app.clickup.com/t/1c208d3

Currently, when calling the compendia API  for a wallet, the `vote` attribute is a main attribute (and not an attribute inside the `attributes` property)

This is not properly handled on the method to get the `votes`.

Because of that, the compendia wallets that have a vote are handled as if they didn't have votes on the desktop wallet as described on the issue.