### PR TITLE
refactor(lsk): calculate amount of `unlockToken` transaction

### DIFF
--- a/packages/sdk-lsk/source/signed-transaction.dto.test.ts
+++ b/packages/sdk-lsk/source/signed-transaction.dto.test.ts
@@ -3,7 +3,7 @@ import "jest-extended";
 import { DateTime } from "@payvo/intl";
 import { BigNumber } from "@payvo/helpers";
 
-import { createService, require } from "../test/mocking";
+import { createService } from "../test/mocking";
 import { SignedTransactionData } from "./signed-transaction.dto";
 
 let subject: SignedTransactionData;
@@ -234,9 +234,37 @@ describe("3.0", () => {
 		expect(subject.recipient()).toBe(transaction.asset.recipientAddress);
 	});
 
-	test("#amount", () => {
+	test("#amount", async () => {
 		expect(subject.amount()).toBeInstanceOf(BigNumber);
 		expect(subject.amount().toString()).toMatchInlineSnapshot(`"100000000"`);
+
+		// unlockToken
+		subject = await createService(SignedTransactionData).configure(
+			transaction.id,
+			{
+				...transaction,
+				moduleID: 5,
+				assetID: 2,
+				asset: {
+					unlockObjects: [
+						{
+							"delegateAddress": "lskc579agejjw3fo9nvgg85r8vo6sa5xojtw9qscj",
+							"amount": "2000000000",
+							"unvoteHeight": 14548930
+						},
+						{
+							"delegateAddress": "8c955e70d0da3e0424abc4c0683280232f41c48b",
+							"amount": "3000000000",
+							"unvoteHeight": 14548929
+						}
+					]
+				}
+			},
+			transaction,
+		);
+
+		expect(subject.amount()).toBeInstanceOf(BigNumber);
+		expect(subject.amount().toString()).toMatchInlineSnapshot(`"5000000000"`);
 	});
 
 	test("#fee", () => {

--- a/packages/sdk-lsk/source/signed-transaction.dto.test.ts
+++ b/packages/sdk-lsk/source/signed-transaction.dto.test.ts
@@ -234,37 +234,40 @@ describe("3.0", () => {
 		expect(subject.recipient()).toBe(transaction.asset.recipientAddress);
 	});
 
-	test("#amount", async () => {
-		expect(subject.amount()).toBeInstanceOf(BigNumber);
-		expect(subject.amount().toString()).toMatchInlineSnapshot(`"100000000"`);
+	describe("#amount", () => {
+		it("returns transaction amount", () => {
+			expect(subject.amount()).toBeInstanceOf(BigNumber);
+			expect(subject.amount().toString()).toMatchInlineSnapshot(`"100000000"`);
+		});
 
-		// unlockToken
-		subject = await createService(SignedTransactionData).configure(
-			transaction.id,
-			{
-				...transaction,
-				moduleID: 5,
-				assetID: 2,
-				asset: {
-					unlockObjects: [
-						{
-							delegateAddress: "lskc579agejjw3fo9nvgg85r8vo6sa5xojtw9qscj",
-							amount: "2000000000",
-							unvoteHeight: 14548930,
-						},
-						{
-							delegateAddress: "8c955e70d0da3e0424abc4c0683280232f41c48b",
-							amount: "3000000000",
-							unvoteHeight: 14548929,
-						},
-					],
+		it("returns sum of unlock objects amounts if type is unlockToken", async () => {
+			subject = await createService(SignedTransactionData).configure(
+				transaction.id,
+				{
+					...transaction,
+					moduleID: 5,
+					assetID: 2,
+					asset: {
+						unlockObjects: [
+							{
+								delegateAddress: "lskc579agejjw3fo9nvgg85r8vo6sa5xojtw9qscj",
+								amount: "2000000000",
+								unvoteHeight: 14548930,
+							},
+							{
+								delegateAddress: "8c955e70d0da3e0424abc4c0683280232f41c48b",
+								amount: "3000000000",
+								unvoteHeight: 14548929,
+							},
+						],
+					},
 				},
-			},
-			transaction,
-		);
+				transaction,
+			);
 
-		expect(subject.amount()).toBeInstanceOf(BigNumber);
-		expect(subject.amount().toString()).toMatchInlineSnapshot(`"5000000000"`);
+			expect(subject.amount()).toBeInstanceOf(BigNumber);
+			expect(subject.amount().toString()).toMatchInlineSnapshot(`"5000000000"`);
+		});
 	});
 
 	test("#fee", () => {

--- a/packages/sdk-lsk/source/signed-transaction.dto.ts
+++ b/packages/sdk-lsk/source/signed-transaction.dto.ts
@@ -34,7 +34,13 @@ export class SignedTransactionData
 
 	public override amount(): BigNumber {
 		if (this.isUnlockToken()) {
-			return this.#unlockTokenAmount();
+			let amount = this.bigNumberService.make(0);
+
+			for (const unlockObject of this.signedData.asset.unlockObjects) {
+				amount = amount.plus(this.bigNumberService.make(unlockObject.amount));
+			}
+
+			return amount;
 		}
 
 		if (this.signedData.moduleID) {
@@ -130,15 +136,5 @@ export class SignedTransactionData
 		}
 
 		return TransactionTypeService.isUnlockToken(this.signedData);
-	}
-
-	#unlockTokenAmount(): BigNumber {
-		let amount = this.bigNumberService.make(0);
-
-		for (const unlockObject of this.signedData.asset.unlockObjects) {
-			amount = amount.plus(this.bigNumberService.make(unlockObject.amount));
-		}
-
-		return amount;
 	}
 }

--- a/packages/sdk-lsk/source/signed-transaction.dto.ts
+++ b/packages/sdk-lsk/source/signed-transaction.dto.ts
@@ -33,6 +33,10 @@ export class SignedTransactionData
 	}
 
 	public override amount(): BigNumber {
+		if (this.isUnlockToken()) {
+			return this.#unlockTokenAmount();
+		}
+
 		if (this.signedData.moduleID) {
 			return this.bigNumberService.make(this.signedData.asset.amount);
 		}
@@ -126,5 +130,15 @@ export class SignedTransactionData
 		}
 
 		return TransactionTypeService.isUnlockToken(this.signedData);
+	}
+
+	#unlockTokenAmount(): BigNumber {
+		let amount = this.bigNumberService.make(0);
+
+		for (const unlockObject of this.signedData.asset.unlockObjects) {
+			amount = amount.plus(this.bigNumberService.make(unlockObject.amount));
+		}
+
+		return amount;
 	}
 }


### PR DESCRIPTION
The goal of this PR is to update the `amount` method of `SignedTransactionData`. When the transaction type is "unlockToken", it will return the sum of the amount of all the unlock objects included.