### PR TITLE
fix(lsk): use locale on BIP39 validation

### DIFF
--- a/packages/sdk-ark/source/key-pair.service.ts
+++ b/packages/sdk-ark/source/key-pair.service.ts
@@ -22,7 +22,10 @@ export class KeyPairService extends Services.AbstractKeyPairService {
 		return { publicKey, privateKey };
 	}
 
-	public override async fromSecret(secret: string, bip39Locale?: string): Promise<Services.KeyPairDataTransferObject> {
+	public override async fromSecret(
+		secret: string,
+		bip39Locale?: string,
+	): Promise<Services.KeyPairDataTransferObject> {
 		abort_if(
 			BIP39.validate(secret, bip39Locale),
 			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",

--- a/packages/sdk-lsk/source/address.service.test.ts
+++ b/packages/sdk-lsk/source/address.service.test.ts
@@ -3,7 +3,7 @@ import "jest-extended";
 import { IoC } from "@payvo/sdk";
 
 import { createService, require } from "../test/mocking";
-import { identity } from "../test/fixtures/identity";
+import { identity, identityByLocale } from "../test/fixtures/identity";
 import { AddressService } from "./address.service";
 
 let subject: AddressService;
@@ -21,10 +21,29 @@ describe("Address", () => {
 		expect(result).toEqual({ type: "bip39", address: identity.address });
 	});
 
+	it("should generate an output from a mnemonic given a custom locale", async () => {
+		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+
+		expect(result).toEqual({ type: "bip39", address: identityByLocale.french.address });
+	});
+
 	it("should generate an output from a publicKey", async () => {
 		const result = await subject.fromPublicKey(identity.publicKey);
 
 		expect(result).toEqual({ type: "bip39", address: identity.address });
+	});
+
+	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
+		await expect(subject.fromSecret(identityByLocale.french.mnemonic, { bip39Locale: "french" })).rejects.toEqual(
+			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
+		);
+
+		await expect(subject.fromSecret(identityByLocale.french.mnemonic, { bip39Locale: "english" })).resolves.toEqual(
+			{
+				address: identityByLocale.french.address,
+				type: "bip39",
+			},
+		);
 	});
 
 	it("should validate an address", async () => {

--- a/packages/sdk-lsk/source/address.service.ts
+++ b/packages/sdk-lsk/source/address.service.ts
@@ -13,7 +13,7 @@ export class AddressService extends Services.AbstractAddressService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.AddressDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
 
 		return { type: "bip39", address: getLisk32AddressFromPassphrase(mnemonic) };
 	}
@@ -25,8 +25,14 @@ export class AddressService extends Services.AbstractAddressService {
 		return { type: "bip39", address: getLisk32AddressFromPublicKey(Buffer.from(publicKey, "hex")) };
 	}
 
-	public override async fromSecret(secret: string): Promise<Services.AddressDataTransferObject> {
-		abort_if(BIP39.validate(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
+	public override async fromSecret(
+		secret: string,
+		options?: Services.IdentityOptions,
+	): Promise<Services.AddressDataTransferObject> {
+		abort_if(
+			BIP39.validate(secret, options?.bip39Locale),
+			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
+		);
 
 		return { type: "bip39", address: getLisk32AddressFromPassphrase(secret) };
 	}

--- a/packages/sdk-lsk/source/key-pair.service.test.ts
+++ b/packages/sdk-lsk/source/key-pair.service.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { identity } from "../test/fixtures/identity";
+import { identity, identityByLocale } from "../test/fixtures/identity";
 import { createService, require } from "../test/mocking";
 import { KeyPairService } from "./key-pair.service";
 
@@ -17,6 +17,26 @@ describe("Keys", () => {
 		expect(result).toEqual({
 			privateKey: identity.privateKey,
 			publicKey: identity.publicKey,
+		});
+	});
+
+	it("should generate an output from a mnemonic given a custom locale", async () => {
+		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+
+		expect(result).toEqual({
+			privateKey: identityByLocale.french.privateKey,
+			publicKey: identityByLocale.french.publicKey,
+		});
+	});
+
+	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
+		await expect(subject.fromSecret(identityByLocale.french.mnemonic, "french")).rejects.toEqual(
+			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
+		);
+
+		await expect(subject.fromSecret(identityByLocale.french.mnemonic)).resolves.toEqual({
+			privateKey: identityByLocale.french.privateKey,
+			publicKey: identityByLocale.french.publicKey,
 		});
 	});
 });

--- a/packages/sdk-lsk/source/key-pair.service.ts
+++ b/packages/sdk-lsk/source/key-pair.service.ts
@@ -9,7 +9,7 @@ export class KeyPairService extends Services.AbstractKeyPairService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.KeyPairDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
 
 		const { publicKey, privateKey } = getPrivateAndPublicKeyFromPassphrase(mnemonic);
 
@@ -19,8 +19,14 @@ export class KeyPairService extends Services.AbstractKeyPairService {
 		};
 	}
 
-	public override async fromSecret(secret: string): Promise<Services.KeyPairDataTransferObject> {
-		abort_if(BIP39.validate(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
+	public override async fromSecret(
+		secret: string,
+		bip39Locale?: string,
+	): Promise<Services.KeyPairDataTransferObject> {
+		abort_if(
+			BIP39.validate(secret, bip39Locale),
+			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
+		);
 
 		const { publicKey, privateKey } = getPrivateAndPublicKeyFromPassphrase(secret);
 

--- a/packages/sdk-lsk/source/private-key.service.test.ts
+++ b/packages/sdk-lsk/source/private-key.service.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { identity } from "../test/fixtures/identity";
+import { identity, identityByLocale } from "../test/fixtures/identity";
 import { createService, require } from "../test/mocking";
 import { PrivateKeyService } from "./private-key.service";
 
@@ -15,5 +15,17 @@ describe("PrivateKey", () => {
 		const result = await subject.fromMnemonic(identity.mnemonic);
 
 		expect(result).toEqual({ privateKey: identity.privateKey });
+	});
+
+	it("should generate an output from a mnemonic given a custom locale", async () => {
+		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+
+		expect(result).toEqual({ privateKey: identityByLocale.french.privateKey });
+	});
+
+	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
+		await expect(subject.fromSecret(identityByLocale.french.mnemonic, "french")).rejects.toEqual(
+			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
+		);
 	});
 });

--- a/packages/sdk-lsk/source/private-key.service.ts
+++ b/packages/sdk-lsk/source/private-key.service.ts
@@ -9,7 +9,7 @@ export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.PrivateKeyDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
 
 		const { privateKey } = getPrivateAndPublicKeyFromPassphrase(mnemonic);
 
@@ -18,8 +18,14 @@ export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 		};
 	}
 
-	public override async fromSecret(secret: string): Promise<Services.PrivateKeyDataTransferObject> {
-		abort_if(BIP39.validate(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
+	public override async fromSecret(
+		secret: string,
+		bip39Locale?: string,
+	): Promise<Services.PrivateKeyDataTransferObject> {
+		abort_if(
+			BIP39.validate(secret, bip39Locale),
+			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
+		);
 
 		const { privateKey } = getPrivateAndPublicKeyFromPassphrase(secret);
 

--- a/packages/sdk-lsk/source/public-key.service.test.ts
+++ b/packages/sdk-lsk/source/public-key.service.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { identity } from "../test/fixtures/identity";
+import { identity, identityByLocale } from "../test/fixtures/identity";
 import { createService, require } from "../test/mocking";
 import { PublicKeyService } from "./public-key.service";
 
@@ -15,5 +15,21 @@ describe("PublicKey", () => {
 		const result = await subject.fromMnemonic(identity.mnemonic);
 
 		expect(result).toEqual({ publicKey: identity.publicKey });
+	});
+
+	it("should generate an output from a mnemonic given a custom locale", async () => {
+		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+
+		expect(result).toEqual({ publicKey: identityByLocale.french.publicKey });
+	});
+
+	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
+		await expect(subject.fromSecret(identityByLocale.french.mnemonic, "french")).rejects.toEqual(
+			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
+		);
+
+		await expect(subject.fromSecret(identityByLocale.french.mnemonic)).resolves.toEqual({
+			publicKey: identityByLocale.french.publicKey,
+		});
 	});
 });

--- a/packages/sdk-lsk/source/public-key.service.ts
+++ b/packages/sdk-lsk/source/public-key.service.ts
@@ -9,15 +9,21 @@ export class PublicKeyService extends Services.AbstractPublicKeyService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.PublicKeyDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
 
 		return {
 			publicKey: getPrivateAndPublicKeyFromPassphrase(mnemonic).publicKey.toString("hex"),
 		};
 	}
 
-	public override async fromSecret(secret: string): Promise<Services.PublicKeyDataTransferObject> {
-		abort_if(BIP39.validate(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
+	public override async fromSecret(
+		secret: string,
+		bip39Locale?: string,
+	): Promise<Services.PublicKeyDataTransferObject> {
+		abort_if(
+			BIP39.validate(secret, bip39Locale),
+			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
+		);
 
 		return {
 			publicKey: getPrivateAndPublicKeyFromPassphrase(secret).publicKey.toString("hex"),

--- a/packages/sdk-lsk/source/wif.service.test.ts
+++ b/packages/sdk-lsk/source/wif.service.test.ts
@@ -1,9 +1,7 @@
 import "jest-extended";
 
-import { Exceptions } from "@payvo/sdk";
-
-import { identity } from "../test/fixtures/identity";
-import { createService, require } from "../test/mocking";
+import { identity, identityByLocale } from "../test/fixtures/identity";
+import { createService } from "../test/mocking";
 import { WIFService } from "./wif.service";
 import { WIF } from "@payvo/cryptography";
 
@@ -21,6 +19,12 @@ describe("WIF", () => {
 		expect(WIF.decode(result.wif).privateKey).toBe(identity.privateKey);
 	});
 
+	it("should generate an output from a mnemonic given a custom locale", async () => {
+		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+
+		expect(result).toEqual({ wif: identityByLocale.french.wif });
+	});
+
 	it("should fail to generate an output from an invalid mnemonic", async () => {
 		await expect(subject.fromMnemonic(undefined!)).rejects.toThrow();
 	});
@@ -30,6 +34,12 @@ describe("WIF", () => {
 
 		expect(result).toEqual({ wif: identity.wif });
 		expect(WIF.decode(result.wif).privateKey).toBe(identity.privateKey);
+	});
+
+	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
+		await expect(subject.fromSecret(identityByLocale.french.mnemonic, "french")).rejects.toEqual(
+			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
+		);
 	});
 
 	it("should fail to generate an output from an invalid private key", async () => {

--- a/packages/sdk-lsk/source/wif.service.ts
+++ b/packages/sdk-lsk/source/wif.service.ts
@@ -10,7 +10,7 @@ export class WIFService extends Services.AbstractWIFService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.WIFDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
 
 		return {
 			wif: WIF.encode({
@@ -33,8 +33,11 @@ export class WIFService extends Services.AbstractWIFService {
 		};
 	}
 
-	public override async fromSecret(secret: string): Promise<Services.WIFDataTransferObject> {
-		abort_if(BIP39.validate(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
+	public override async fromSecret(secret: string, bip39Locale?: string): Promise<Services.WIFDataTransferObject> {
+		abort_if(
+			BIP39.validate(secret, bip39Locale),
+			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
+		);
 
 		return {
 			wif: WIF.encode({

--- a/packages/sdk-lsk/test/fixtures/identity.ts
+++ b/packages/sdk-lsk/test/fixtures/identity.ts
@@ -11,3 +11,14 @@ export const identity = {
 	multiSignatureAddress: undefined,
 	multiSignaturePublicKey: undefined,
 };
+
+export const identityByLocale = {
+	french: {
+		wif: "LwUyTS2NXysbDezkTfqhrdUbv7gfSSXQEh3UrLC3sEM6QeASUTMZ",
+		privateKey: "ca6bc86f1ba22a25556fb3db912b24e4dedc39f8031ca7dd8ab3ee49fae2fe45",
+		publicKey: "89e68bd2c10eaa8abdf886a17d8d983c784d8c4ec236beb0acdd4d125470e841",
+		address: "lsk879yhgfq4875sdmasxv543sz85nhh6xyjrtap8",
+		mnemonic:
+			"arbitre dauphin révolte riposter fatigue rotatif exécuter ravager renvoi automne boiser bistouri caneton sélectif chose achat tumulte prospère léger effigie buffle microbe oxyde appareil",
+	},
+};


### PR DESCRIPTION
Depends on https://github.com/PayvoHQ/sdk/pull/237