### PR TITLE
refactor: revert `bip39Locale` parameter

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
   ../../packages/sdk-ada:
     dependencies:
       '@emurgo/cardano-serialization-lib-nodejs': 8.0.0
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -139,7 +139,7 @@ importers:
     specifiers:
       '@emurgo/cardano-serialization-lib-nodejs': ^8.0.0
       '@jest/globals': ^27.0.6
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -180,7 +180,7 @@ importers:
       '@arkecosystem/ledger-transport': 2.0.0
       '@arkecosystem/utils': 1.3.0
       '@ledgerhq/hw-transport-node-hid-singleton': 6.3.0
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -232,7 +232,7 @@ importers:
       '@jest/globals': ^27.0.6
       '@ledgerhq/hw-transport-mocker': ^6.3.0
       '@ledgerhq/hw-transport-node-hid-singleton': ^6.3.0
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -275,7 +275,7 @@ importers:
       typescript: ^4.4.2
   ../../packages/sdk-atom:
     dependencies:
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -317,7 +317,7 @@ importers:
     specifiers:
       '@jest/globals': ^27.0.6
       '@ledgerhq/hw-transport-mocker': ^6.3.0
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -356,7 +356,7 @@ importers:
   ../../packages/sdk-avax:
     dependencies:
       '@arkecosystem/utils': 1.3.0
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -401,7 +401,7 @@ importers:
       '@arkecosystem/utils': ^1.3.0
       '@jest/globals': ^27.0.6
       '@ledgerhq/hw-transport-mocker': ^6.3.0
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -443,7 +443,7 @@ importers:
     dependencies:
       '@ledgerhq/hw-app-btc': 6.3.0
       '@ledgerhq/hw-transport-node-hid-singleton': 6.3.0
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -491,7 +491,7 @@ importers:
       '@ledgerhq/hw-transport-mocker': ^6.3.0
       '@ledgerhq/hw-transport-node-hid-singleton': ^6.3.0
       '@ledgerhq/logs': ~6.2.0
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -531,7 +531,7 @@ importers:
       typescript: ^4.4.2
   ../../packages/sdk-dot:
     dependencies:
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -579,7 +579,7 @@ importers:
     specifiers:
       '@jest/globals': ^27.0.6
       '@ledgerhq/hw-transport-mocker': ^6.3.0
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -625,7 +625,7 @@ importers:
     dependencies:
       '@elrondnetwork/elrond-core-js': 2.1.0
       '@elrondnetwork/erdjs': 7.0.0
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -665,7 +665,7 @@ importers:
       '@elrondnetwork/elrond-core-js': ^2.1.0
       '@elrondnetwork/erdjs': ^7.0.0
       '@jest/globals': ^27.0.6
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -701,7 +701,7 @@ importers:
       typescript: ^4.4.2
   ../../packages/sdk-eos:
     dependencies:
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -744,7 +744,7 @@ importers:
     specifiers:
       '@jest/globals': ^27.0.6
       '@ledgerhq/hw-transport-mocker': ^6.3.0
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -786,7 +786,7 @@ importers:
       '@ethereumjs/common': 2.4.0
       '@ethereumjs/tx': 3.3.0
       '@ledgerhq/hw-app-eth': 6.5.0
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -830,7 +830,7 @@ importers:
       '@jest/globals': ^27.0.6
       '@ledgerhq/hw-app-eth': ^6.5.0
       '@ledgerhq/hw-transport-mocker': ^6.3.0
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -870,7 +870,7 @@ importers:
       '@ledgerhq/hw-transport-node-hid-singleton': 6.3.0
       '@liskhq/lisk-cryptography': 3.1.0
       '@liskhq/lisk-transactions': 5.1.1
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -912,7 +912,7 @@ importers:
       '@ledgerhq/hw-transport-node-hid-singleton': ^6.3.0
       '@liskhq/lisk-cryptography': ^3.1
       '@liskhq/lisk-transactions': ^5.1
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -947,7 +947,7 @@ importers:
       typescript: ^4.4.2
   ../../packages/sdk-luna:
     dependencies:
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -985,7 +985,7 @@ importers:
       typescript: 4.4.2
     specifiers:
       '@jest/globals': ^27.0.6
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -1021,7 +1021,7 @@ importers:
       typescript: ^4.4.2
   ../../packages/sdk-nano:
     dependencies:
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -1061,7 +1061,7 @@ importers:
       typescript: 4.4.2
     specifiers:
       '@jest/globals': ^27.0.6
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -1100,7 +1100,7 @@ importers:
   ../../packages/sdk-neo:
     dependencies:
       '@cityofzion/neon-js': 4.9.0
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -1140,7 +1140,7 @@ importers:
       '@cityofzion/neon-js': ^4.9.0
       '@jest/globals': ^27.0.6
       '@ledgerhq/hw-transport-mocker': ^6.3.0
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -1175,7 +1175,7 @@ importers:
       typescript: ^4.4.2
   ../../packages/sdk-sol:
     dependencies:
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -1215,7 +1215,7 @@ importers:
       typescript: 4.4.2
     specifiers:
       '@jest/globals': ^27.0.6
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -1254,7 +1254,7 @@ importers:
   ../../packages/sdk-trx:
     dependencies:
       '@ledgerhq/hw-app-trx': 6.3.0
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -1293,7 +1293,7 @@ importers:
       '@jest/globals': ^27.0.6
       '@ledgerhq/hw-app-trx': ^6.3.0
       '@ledgerhq/hw-transport-mocker': ^6.3.0
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -1328,7 +1328,7 @@ importers:
   ../../packages/sdk-xlm:
     dependencies:
       '@ledgerhq/hw-app-str': 6.3.0
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -1368,7 +1368,7 @@ importers:
       '@jest/globals': ^27.0.6
       '@ledgerhq/hw-app-str': ^6.3.0
       '@ledgerhq/hw-transport-mocker': ^6.3.0
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -1404,7 +1404,7 @@ importers:
   ../../packages/sdk-xrp:
     dependencies:
       '@ledgerhq/hw-app-xrp': 6.3.0
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -1450,7 +1450,7 @@ importers:
       '@jest/globals': ^27.0.6
       '@ledgerhq/hw-app-xrp': ^6.3.0
       '@ledgerhq/hw-transport-mocker': ^6.3.0
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -1491,7 +1491,7 @@ importers:
       typescript-language-server: ^0.6.1
   ../../packages/sdk-zil:
     dependencies:
-      '@payvo/cryptography': 1.1.4
+      '@payvo/cryptography': 1.1.5
       '@payvo/helpers': 1.1.1
       '@payvo/intl': 1.0.1
       '@payvo/sdk': link:../sdk
@@ -1530,7 +1530,7 @@ importers:
       typescript: 4.4.2
     specifiers:
       '@jest/globals': ^27.0.6
-      '@payvo/cryptography': ^1.1.4
+      '@payvo/cryptography': ^1.1.5
       '@payvo/helpers': ^1.1.1
       '@payvo/http-got': ^1.0.0
       '@payvo/intl': ^1.0.1
@@ -3130,7 +3130,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==
-  /@payvo/cryptography/1.1.4:
+  /@payvo/cryptography/1.1.5:
     dependencies:
       argon2-browser: 1.15.4
       bcryptjs: 2.4.3
@@ -3150,7 +3150,7 @@ packages:
     engines:
       node: '>=12.x'
     resolution:
-      integrity: sha512-wcS+b3bp/kmQubdtKRfQGGn9KCGpbf5zLpm9ujk/rox9jJc1nbhOJoTPt+nAtLQOALbGdS/aBTDgEgOtJjErEg==
+      integrity: sha512-lLFPYS9ksnoleu+4KBhk4Ne0r7fuj0eAdvSCZ1b+THBO5msCf6zfLmhQHyk1iVsgoQUlDWwa4T/Hu/q3e7zDfg==
   /@payvo/helpers/1.1.1:
     dependencies:
       bad-words: 3.0.4

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "def33d9bf9ab44f09eceb6163f2e3e2cdc795943",
+  "pnpmShrinkwrapHash": "21eb3a99d5475a8a4182ef12e60af2f2658abbd8",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/sdk-ada/package.json
+++ b/packages/sdk-ada/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"@emurgo/cardano-serialization-lib-nodejs": "^8.0.0",
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-ark/package.json
+++ b/packages/sdk-ark/package.json
@@ -30,7 +30,7 @@
 		"@arkecosystem/ledger-transport": "^2.0.0",
 		"@arkecosystem/utils": "^1.3.0",
 		"@ledgerhq/hw-transport-node-hid-singleton": "^6.3.0",
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-ark/source/address.service.test.ts
+++ b/packages/sdk-ark/source/address.service.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { identity, identityByLocale } from "../test/fixtures/identity";
+import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { AddressService } from "./address.service";
 
@@ -18,9 +18,9 @@ describe("Address", () => {
 	});
 
 	it("should generate an output from a mnemonic given a custom locale", async () => {
-		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+		const result = await subject.fromMnemonic(identity.mnemonic);
 
-		expect(result).toEqual({ type: "bip39", address: identityByLocale.french.address });
+		expect(result).toEqual({ type: "bip39", address: identity.address });
 	});
 
 	it("should generate an output from a multiSignature", async () => {
@@ -45,22 +45,13 @@ describe("Address", () => {
 	});
 
 	it("should generate an output from a secret", async () => {
-		const result = await subject.fromSecret("abc");
-
-		expect(result).toEqual({ type: "bip39", address: "DNTwQTSp999ezQ425utBsWetcmzDuCn2pN" });
-	});
-
-	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, { bip39Locale: "french" })).rejects.toEqual(
+		await expect(subject.fromSecret(identity.mnemonic)).rejects.toEqual(
 			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
 		);
 
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, { bip39Locale: "english" })).resolves.toEqual(
-			{
-				address: identityByLocale.french.address,
-				type: "bip39",
-			},
-		);
+		const result = await subject.fromSecret("abc");
+
+		expect(result).toEqual({ type: "bip39", address: "DNTwQTSp999ezQ425utBsWetcmzDuCn2pN" });
 	});
 
 	it("should generate an output from a wif", async () => {

--- a/packages/sdk-ark/source/address.service.ts
+++ b/packages/sdk-ark/source/address.service.ts
@@ -15,7 +15,7 @@ export class AddressService extends Services.AbstractAddressService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.AddressDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		return {
 			type: "bip39",
@@ -53,14 +53,8 @@ export class AddressService extends Services.AbstractAddressService {
 		};
 	}
 
-	public override async fromSecret(
-		secret: string,
-		options?: Services.IdentityOptions,
-	): Promise<Services.AddressDataTransferObject> {
-		abort_if(
-			BIP39.validate(secret, options?.bip39Locale),
-			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
-		);
+	public override async fromSecret(secret: string): Promise<Services.AddressDataTransferObject> {
+		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
 		return {
 			type: "bip39",

--- a/packages/sdk-ark/source/key-pair.service.test.ts
+++ b/packages/sdk-ark/source/key-pair.service.test.ts
@@ -1,9 +1,7 @@
 import "jest-extended";
 
-import { Exceptions } from "@payvo/sdk";
-
-import { identity, identityByLocale } from "../test/fixtures/identity";
-import { createService, require } from "../test/mocking";
+import { identity } from "../test/fixtures/identity";
+import { createService } from "../test/mocking";
 import { KeyPairService } from "./key-pair.service";
 
 let subject: KeyPairService;
@@ -23,11 +21,11 @@ describe("Keys", () => {
 	});
 
 	it("should generate an output from a mnemonic given a custom locale", async () => {
-		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+		const result = await subject.fromMnemonic(identity.mnemonic);
 
 		expect(result).toEqual({
-			privateKey: identityByLocale.french.privateKey,
-			publicKey: identityByLocale.french.publicKey,
+			privateKey: identity.privateKey,
+			publicKey: identity.publicKey,
 		});
 	});
 
@@ -49,22 +47,15 @@ describe("Keys", () => {
 	});
 
 	it("should generate an output from a secret", async () => {
+		await expect(subject.fromSecret(identity.mnemonic)).rejects.toEqual(
+			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
+		);
+
 		const result = await subject.fromSecret("abc");
 
 		expect(result).toEqual({
 			privateKey: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 			publicKey: "0223542d61708e3fc48ba78fbe8fcc983ba94a520bc33f82b8e45e51dbc47af272",
-		});
-	});
-
-	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, "french")).rejects.toEqual(
-			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
-		);
-
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic)).resolves.toEqual({
-			privateKey: identityByLocale.french.privateKey,
-			publicKey: identityByLocale.french.publicKey,
 		});
 	});
 

--- a/packages/sdk-ark/source/key-pair.service.ts
+++ b/packages/sdk-ark/source/key-pair.service.ts
@@ -15,21 +15,15 @@ export class KeyPairService extends Services.AbstractKeyPairService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.KeyPairDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		const { publicKey, privateKey } = BaseKeys.fromPassphrase(mnemonic, true);
 
 		return { publicKey, privateKey };
 	}
 
-	public override async fromSecret(
-		secret: string,
-		bip39Locale?: string,
-	): Promise<Services.KeyPairDataTransferObject> {
-		abort_if(
-			BIP39.validate(secret, bip39Locale),
-			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
-		);
+	public override async fromSecret(secret: string): Promise<Services.KeyPairDataTransferObject> {
+		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
 		const { publicKey, privateKey } = BaseKeys.fromPassphrase(secret, true);
 

--- a/packages/sdk-ark/source/private-key.service.test.ts
+++ b/packages/sdk-ark/source/private-key.service.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { identity, identityByLocale } from "../test/fixtures/identity";
+import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { PrivateKeyService } from "./private-key.service";
 
@@ -18,9 +18,9 @@ describe("PrivateKey", () => {
 	});
 
 	it("should generate an output from a mnemonic given a custom locale", async () => {
-		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+		const result = await subject.fromMnemonic(identity.mnemonic);
 
-		expect(result).toEqual({ privateKey: identityByLocale.french.privateKey });
+		expect(result).toEqual({ privateKey: identity.privateKey });
 	});
 	it("should fail to generate an output from an invalid mnemonic", async () => {
 		await expect(subject.fromMnemonic(undefined!)).rejects.toThrow();
@@ -37,21 +37,13 @@ describe("PrivateKey", () => {
 	});
 
 	it("should generate an output from a secret", async () => {
-		const result = await subject.fromSecret("abc");
-
-		expect(result).toEqual({ privateKey: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad" });
-	});
-
-	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, { bip39Locale: "french" })).rejects.toEqual(
+		await expect(subject.fromSecret(identity.mnemonic)).rejects.toEqual(
 			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
 		);
 
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, { bip39Locale: "english" })).resolves.toEqual(
-			{
-				privateKey: identityByLocale.french.privateKey,
-			},
-		);
+		const result = await subject.fromSecret("abc");
+
+		expect(result).toEqual({ privateKey: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad" });
 	});
 
 	it("should fail to generate an output from an invalid secret", async () => {

--- a/packages/sdk-ark/source/private-key.service.ts
+++ b/packages/sdk-ark/source/private-key.service.ts
@@ -15,21 +15,15 @@ export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.PrivateKeyDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		return {
 			privateKey: BasePrivateKey.fromPassphrase(mnemonic),
 		};
 	}
 
-	public override async fromSecret(
-		secret: string,
-		options?: Services.IdentityOptions,
-	): Promise<Services.PrivateKeyDataTransferObject> {
-		abort_if(
-			BIP39.validate(secret, options?.bip39Locale),
-			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
-		);
+	public override async fromSecret(secret: string): Promise<Services.PrivateKeyDataTransferObject> {
+		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
 		return {
 			privateKey: BasePrivateKey.fromPassphrase(secret),

--- a/packages/sdk-ark/source/public-key.service.test.ts
+++ b/packages/sdk-ark/source/public-key.service.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { identity, identityByLocale } from "../test/fixtures/identity";
+import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { PublicKeyService } from "./public-key.service";
 
@@ -18,9 +18,9 @@ describe("PublicKey", () => {
 	});
 
 	it("should generate an output from a mnemonic given a custom locale", async () => {
-		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+		const result = await subject.fromMnemonic(identity.mnemonic);
 
-		expect(result).toEqual({ publicKey: identityByLocale.french.publicKey });
+		expect(result).toEqual({ publicKey: identity.publicKey });
 	});
 
 	it("should fail to generate an output from an invalid mnemonic", async () => {
@@ -51,19 +51,13 @@ describe("PublicKey", () => {
 	});
 
 	it("should generate an output from a secret", async () => {
-		const result = await subject.fromSecret("abc");
-
-		expect(result).toEqual({ publicKey: "0223542d61708e3fc48ba78fbe8fcc983ba94a520bc33f82b8e45e51dbc47af272" });
-	});
-
-	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, "french")).rejects.toEqual(
+		await expect(subject.fromSecret(identity.mnemonic)).rejects.toEqual(
 			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
 		);
 
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic)).resolves.toEqual({
-			publicKey: identityByLocale.french.publicKey,
-		});
+		const result = await subject.fromSecret("abc");
+
+		expect(result).toEqual({ publicKey: "0223542d61708e3fc48ba78fbe8fcc983ba94a520bc33f82b8e45e51dbc47af272" });
 	});
 
 	it("should fail to generate an output from a secret", async () => {

--- a/packages/sdk-ark/source/public-key.service.ts
+++ b/packages/sdk-ark/source/public-key.service.ts
@@ -15,7 +15,7 @@ export class PublicKeyService extends Services.AbstractPublicKeyService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.PublicKeyDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		return {
 			publicKey: BasePublicKey.fromPassphrase(mnemonic),
@@ -31,14 +31,8 @@ export class PublicKeyService extends Services.AbstractPublicKeyService {
 		};
 	}
 
-	public override async fromSecret(
-		secret: string,
-		bip39Locale?: string,
-	): Promise<Services.PublicKeyDataTransferObject> {
-		abort_if(
-			BIP39.validate(secret, bip39Locale),
-			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
-		);
+	public override async fromSecret(secret: string): Promise<Services.PublicKeyDataTransferObject> {
+		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
 		return {
 			publicKey: BasePublicKey.fromPassphrase(secret),

--- a/packages/sdk-ark/source/wif.service.test.ts
+++ b/packages/sdk-ark/source/wif.service.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { identity, identityByLocale } from "../test/fixtures/identity";
+import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { WIFService } from "./wif.service";
 
@@ -18,9 +18,9 @@ describe("WIF", () => {
 	});
 
 	it("should generate an output from a mnemonic given a custom locale", async () => {
-		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+		const result = await subject.fromMnemonic(identity.mnemonic);
 
-		expect(result).toEqual({ wif: identityByLocale.french.wif });
+		expect(result).toEqual({ wif: identity.wif });
 	});
 	it("should fail to generate an output from an invalid mnemonic", async () => {
 		await expect(subject.fromMnemonic(undefined!)).rejects.toThrow();
@@ -37,19 +37,13 @@ describe("WIF", () => {
 	});
 
 	it("should generate an output from a secret", async () => {
-		const result = await subject.fromSecret("abc");
-
-		expect(result).toEqual({ wif: "SFpfYkttf168Ssa96XG5RjzpPCuMo3S2GDJuZorV9auX3cTQJdqW" });
-	});
-
-	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, "french")).rejects.toEqual(
+		await expect(subject.fromSecret(identity.mnemonic)).rejects.toEqual(
 			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
 		);
 
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic)).resolves.toEqual({
-			wif: identityByLocale.french.wif,
-		});
+		const result = await subject.fromSecret("abc");
+
+		expect(result).toEqual({ wif: "SFpfYkttf168Ssa96XG5RjzpPCuMo3S2GDJuZorV9auX3cTQJdqW" });
 	});
 
 	it("should fail to generate an output from an invalid secret", async () => {

--- a/packages/sdk-ark/source/wif.service.ts
+++ b/packages/sdk-ark/source/wif.service.ts
@@ -15,18 +15,15 @@ export class WIFService extends Services.AbstractWIFService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.WIFDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		return {
 			wif: BaseWIF.fromPassphrase(mnemonic, this.config.network),
 		};
 	}
 
-	public override async fromSecret(secret: string, bip39Locale?: string): Promise<Services.WIFDataTransferObject> {
-		abort_if(
-			BIP39.validate(secret, bip39Locale),
-			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
-		);
+	public override async fromSecret(secret: string): Promise<Services.WIFDataTransferObject> {
+		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
 		return {
 			wif: BaseWIF.fromPassphrase(secret, this.config.network),

--- a/packages/sdk-ark/test/fixtures/identity.ts
+++ b/packages/sdk-ark/test/fixtures/identity.ts
@@ -15,14 +15,3 @@ export const identity = {
 	multiSignatureAddress: "DMS861mLRrtH47QUMVif3C2rBCAdHbmwsi",
 	multiSignaturePublicKey: "0279f05076556da7173610a7676399c3620276ebbf8c67552ad3b1f26ec7627794",
 };
-
-export const identityByLocale = {
-	french: {
-		wif: "SGMg3EzkqWrYJHUQNQ3rWtt8skv9VWHa6bUAzgfTYTUiYZNrqWK1",
-		privateKey: "ca6bc86f1ba22a25556fb3db912b24e4dedc39f8031ca7dd8ab3ee49fae2fe45",
-		publicKey: "02e219a960fb9e2f052036c2f41fb2f4ad51dcc1e6bf293e25a68cb1b8e9c3b0de",
-		address: "DJoeLnqjVKHCDnDqKVhoq7TwDbvqk3fHk6",
-		mnemonic:
-			"arbitre dauphin révolte riposter fatigue rotatif exécuter ravager renvoi automne boiser bistouri caneton sélectif chose achat tumulte prospère léger effigie buffle microbe oxyde appareil",
-	},
-};

--- a/packages/sdk-atom/package.json
+++ b/packages/sdk-atom/package.json
@@ -25,7 +25,7 @@
 		"preset": "../../jest.config.js"
 	},
 	"dependencies": {
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-avax/package.json
+++ b/packages/sdk-avax/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"@arkecosystem/utils": "^1.3.0",
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-btc/package.json
+++ b/packages/sdk-btc/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"@ledgerhq/hw-app-btc": "^6.3.0",
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-dot/package.json
+++ b/packages/sdk-dot/package.json
@@ -25,7 +25,7 @@
 		"preset": "../../jest.config.js"
 	},
 	"dependencies": {
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-egld/package.json
+++ b/packages/sdk-egld/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"@elrondnetwork/elrond-core-js": "^2.1.0",
 		"@elrondnetwork/erdjs": "^7.0.0",
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-eos/package.json
+++ b/packages/sdk-eos/package.json
@@ -25,7 +25,7 @@
 		"preset": "../../jest.config.js"
 	},
 	"dependencies": {
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-eth/package.json
+++ b/packages/sdk-eth/package.json
@@ -28,7 +28,7 @@
 		"@ethereumjs/common": "^2.4.0",
 		"@ethereumjs/tx": "^3.3.0",
 		"@ledgerhq/hw-app-eth": "^6.5.0",
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-lsk/package.json
+++ b/packages/sdk-lsk/package.json
@@ -28,7 +28,7 @@
 		"@ledgerhq/hw-transport-node-hid-singleton": "^6.3.0",
 		"@liskhq/lisk-cryptography": "^3.1",
 		"@liskhq/lisk-transactions": "^5.1",
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-lsk/source/address.service.test.ts
+++ b/packages/sdk-lsk/source/address.service.test.ts
@@ -3,7 +3,7 @@ import "jest-extended";
 import { IoC } from "@payvo/sdk";
 
 import { createService, require } from "../test/mocking";
-import { identity, identityByLocale } from "../test/fixtures/identity";
+import { identity } from "../test/fixtures/identity";
 import { AddressService } from "./address.service";
 
 let subject: AddressService;
@@ -22,9 +22,9 @@ describe("Address", () => {
 	});
 
 	it("should generate an output from a mnemonic given a custom locale", async () => {
-		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+		const result = await subject.fromMnemonic(identity.mnemonic);
 
-		expect(result).toEqual({ type: "bip39", address: identityByLocale.french.address });
+		expect(result).toEqual({ type: "bip39", address: identity.address });
 	});
 
 	it("should generate an output from a publicKey", async () => {
@@ -33,17 +33,15 @@ describe("Address", () => {
 		expect(result).toEqual({ type: "bip39", address: identity.address });
 	});
 
-	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, { bip39Locale: "french" })).rejects.toEqual(
+	it("should generate an output from a secret", async () => {
+		await expect(subject.fromSecret(identity.mnemonic)).rejects.toEqual(
 			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
 		);
 
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, { bip39Locale: "english" })).resolves.toEqual(
-			{
-				address: identityByLocale.french.address,
-				type: "bip39",
-			},
-		);
+		await expect(subject.fromSecret("secret")).resolves.toEqual({
+			address: "lskn65ygkx543cg23m6db4ed8myd4ysrsu8q8pbug",
+			type: "bip39",
+		});
 	});
 
 	it("should validate an address", async () => {

--- a/packages/sdk-lsk/source/address.service.ts
+++ b/packages/sdk-lsk/source/address.service.ts
@@ -13,7 +13,7 @@ export class AddressService extends Services.AbstractAddressService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.AddressDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		return { type: "bip39", address: getLisk32AddressFromPassphrase(mnemonic) };
 	}
@@ -25,14 +25,8 @@ export class AddressService extends Services.AbstractAddressService {
 		return { type: "bip39", address: getLisk32AddressFromPublicKey(Buffer.from(publicKey, "hex")) };
 	}
 
-	public override async fromSecret(
-		secret: string,
-		options?: Services.IdentityOptions,
-	): Promise<Services.AddressDataTransferObject> {
-		abort_if(
-			BIP39.validate(secret, options?.bip39Locale),
-			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
-		);
+	public override async fromSecret(secret: string): Promise<Services.AddressDataTransferObject> {
+		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
 		return { type: "bip39", address: getLisk32AddressFromPassphrase(secret) };
 	}

--- a/packages/sdk-lsk/source/key-pair.service.test.ts
+++ b/packages/sdk-lsk/source/key-pair.service.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { identity, identityByLocale } from "../test/fixtures/identity";
+import { identity } from "../test/fixtures/identity";
 import { createService, require } from "../test/mocking";
 import { KeyPairService } from "./key-pair.service";
 
@@ -21,22 +21,22 @@ describe("Keys", () => {
 	});
 
 	it("should generate an output from a mnemonic given a custom locale", async () => {
-		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+		const result = await subject.fromMnemonic(identity.mnemonic);
 
 		expect(result).toEqual({
-			privateKey: identityByLocale.french.privateKey,
-			publicKey: identityByLocale.french.publicKey,
+			privateKey: identity.privateKey,
+			publicKey: identity.publicKey,
 		});
 	});
 
-	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, "french")).rejects.toEqual(
+	it("should generate an output from a secret", async () => {
+		await expect(subject.fromSecret(identity.mnemonic)).rejects.toEqual(
 			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
 		);
 
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic)).resolves.toEqual({
-			privateKey: identityByLocale.french.privateKey,
-			publicKey: identityByLocale.french.publicKey,
+		await expect(subject.fromSecret("secret")).resolves.toEqual({
+			privateKey: "2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b",
+			publicKey: "5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09",
 		});
 	});
 });

--- a/packages/sdk-lsk/source/key-pair.service.ts
+++ b/packages/sdk-lsk/source/key-pair.service.ts
@@ -5,11 +5,8 @@ import { abort_if, abort_unless } from "@payvo/helpers";
 
 @IoC.injectable()
 export class KeyPairService extends Services.AbstractKeyPairService {
-	public override async fromMnemonic(
-		mnemonic: string,
-		options?: Services.IdentityOptions,
-	): Promise<Services.KeyPairDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
+	public override async fromMnemonic(mnemonic: string): Promise<Services.KeyPairDataTransferObject> {
+		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		const { publicKey, privateKey } = getPrivateAndPublicKeyFromPassphrase(mnemonic);
 
@@ -19,14 +16,8 @@ export class KeyPairService extends Services.AbstractKeyPairService {
 		};
 	}
 
-	public override async fromSecret(
-		secret: string,
-		bip39Locale?: string,
-	): Promise<Services.KeyPairDataTransferObject> {
-		abort_if(
-			BIP39.validate(secret, bip39Locale),
-			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
-		);
+	public override async fromSecret(secret: string): Promise<Services.KeyPairDataTransferObject> {
+		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
 		const { publicKey, privateKey } = getPrivateAndPublicKeyFromPassphrase(secret);
 

--- a/packages/sdk-lsk/source/networks/shared.ts
+++ b/packages/sdk-lsk/source/networks/shared.ts
@@ -26,11 +26,6 @@ export const importMethods: Networks.NetworkManifestImportMethods = {
 		default: false,
 		permissions: ["read"],
 	},
-	secret: {
-		default: false,
-		permissions: ["read", "write"],
-		canBeEncrypted: true,
-	},
 };
 
 export const featureFlags: Networks.NetworkManifestFeatureFlags = {

--- a/packages/sdk-lsk/source/private-key.service.test.ts
+++ b/packages/sdk-lsk/source/private-key.service.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
-import { identity, identityByLocale } from "../test/fixtures/identity";
-import { createService, require } from "../test/mocking";
+import { identity } from "../test/fixtures/identity";
+import { createService } from "../test/mocking";
 import { PrivateKeyService } from "./private-key.service";
 
 let subject: PrivateKeyService;
@@ -18,14 +18,20 @@ describe("PrivateKey", () => {
 	});
 
 	it("should generate an output from a mnemonic given a custom locale", async () => {
-		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+		const result = await subject.fromMnemonic(identity.mnemonic);
 
-		expect(result).toEqual({ privateKey: identityByLocale.french.privateKey });
+		expect(result).toEqual({ privateKey: identity.privateKey });
 	});
 
-	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, "french")).rejects.toEqual(
+	it("should generate an output from a secret", async () => {
+		await expect(subject.fromSecret(identity.mnemonic)).rejects.toEqual(
 			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
 		);
+
+		const result = await subject.fromSecret("abc");
+
+		expect(result).toEqual({
+			privateKey: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		});
 	});
 });

--- a/packages/sdk-lsk/source/private-key.service.ts
+++ b/packages/sdk-lsk/source/private-key.service.ts
@@ -9,7 +9,7 @@ export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.PrivateKeyDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		const { privateKey } = getPrivateAndPublicKeyFromPassphrase(mnemonic);
 
@@ -18,19 +18,13 @@ export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 		};
 	}
 
-	public override async fromSecret(
-		secret: string,
-		bip39Locale?: string,
-	): Promise<Services.PrivateKeyDataTransferObject> {
-		abort_if(
-			BIP39.validate(secret, bip39Locale),
-			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
-		);
+	public override async fromSecret(secret: string): Promise<Services.PrivateKeyDataTransferObject> {
+		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
 		const { privateKey } = getPrivateAndPublicKeyFromPassphrase(secret);
 
 		return {
-			privateKey: privateKey.toString("hex"),
+			privateKey: privateKey.toString("hex").substring(0, 64),
 		};
 	}
 }

--- a/packages/sdk-lsk/source/public-key.service.test.ts
+++ b/packages/sdk-lsk/source/public-key.service.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { identity, identityByLocale } from "../test/fixtures/identity";
+import { identity } from "../test/fixtures/identity";
 import { createService, require } from "../test/mocking";
 import { PublicKeyService } from "./public-key.service";
 
@@ -18,18 +18,18 @@ describe("PublicKey", () => {
 	});
 
 	it("should generate an output from a mnemonic given a custom locale", async () => {
-		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+		const result = await subject.fromMnemonic(identity.mnemonic);
 
-		expect(result).toEqual({ publicKey: identityByLocale.french.publicKey });
+		expect(result).toEqual({ publicKey: identity.publicKey });
 	});
 
-	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, "french")).rejects.toEqual(
+	it("should generate an output from a secret", async () => {
+		await expect(subject.fromSecret(identity.mnemonic)).rejects.toEqual(
 			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
 		);
 
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic)).resolves.toEqual({
-			publicKey: identityByLocale.french.publicKey,
+		await expect(subject.fromSecret("secret")).resolves.toEqual({
+			publicKey: "5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09",
 		});
 	});
 });

--- a/packages/sdk-lsk/source/public-key.service.ts
+++ b/packages/sdk-lsk/source/public-key.service.ts
@@ -9,21 +9,15 @@ export class PublicKeyService extends Services.AbstractPublicKeyService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.PublicKeyDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		return {
 			publicKey: getPrivateAndPublicKeyFromPassphrase(mnemonic).publicKey.toString("hex"),
 		};
 	}
 
-	public override async fromSecret(
-		secret: string,
-		bip39Locale?: string,
-	): Promise<Services.PublicKeyDataTransferObject> {
-		abort_if(
-			BIP39.validate(secret, bip39Locale),
-			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
-		);
+	public override async fromSecret(secret: string): Promise<Services.PublicKeyDataTransferObject> {
+		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
 		return {
 			publicKey: getPrivateAndPublicKeyFromPassphrase(secret).publicKey.toString("hex"),

--- a/packages/sdk-lsk/source/wif.service.test.ts
+++ b/packages/sdk-lsk/source/wif.service.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { identity, identityByLocale } from "../test/fixtures/identity";
+import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { WIFService } from "./wif.service";
 import { WIF } from "@payvo/cryptography";
@@ -20,9 +20,9 @@ describe("WIF", () => {
 	});
 
 	it("should generate an output from a mnemonic given a custom locale", async () => {
-		const result = await subject.fromMnemonic(identityByLocale.french.mnemonic, { bip39Locale: "french" });
+		const result = await subject.fromMnemonic(identity.mnemonic);
 
-		expect(result).toEqual({ wif: identityByLocale.french.wif });
+		expect(result).toEqual({ wif: identity.wif });
 	});
 
 	it("should fail to generate an output from an invalid mnemonic", async () => {
@@ -36,10 +36,14 @@ describe("WIF", () => {
 		expect(WIF.decode(result.wif).privateKey).toBe(identity.privateKey);
 	});
 
-	it("should detect if provided input is a bip39 compliant mnemonic based on locale", async () => {
-		await expect(subject.fromSecret(identityByLocale.french.mnemonic, "french")).rejects.toEqual(
+	it("should generate an output from a secret", async () => {
+		await expect(subject.fromSecret(identity.mnemonic)).rejects.toEqual(
 			new Error("The given value is BIP39 compliant. Please use [fromMnemonic] instead."),
 		);
+
+		const result = await subject.fromSecret("abc");
+
+		expect(result).toEqual({ wif: "LvwxxwvWMU7BNF6VBo3vmUbHRZfsjyfrQJtDRTP5UMmtuhLWW4WU" });
 	});
 
 	it("should fail to generate an output from an invalid private key", async () => {

--- a/packages/sdk-lsk/source/wif.service.ts
+++ b/packages/sdk-lsk/source/wif.service.ts
@@ -10,7 +10,7 @@ export class WIFService extends Services.AbstractWIFService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.WIFDataTransferObject> {
-		abort_unless(BIP39.validate(mnemonic, options?.bip39Locale), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		return {
 			wif: WIF.encode({
@@ -33,17 +33,14 @@ export class WIFService extends Services.AbstractWIFService {
 		};
 	}
 
-	public override async fromSecret(secret: string, bip39Locale?: string): Promise<Services.WIFDataTransferObject> {
-		abort_if(
-			BIP39.validate(secret, bip39Locale),
-			"The given value is BIP39 compliant. Please use [fromMnemonic] instead.",
-		);
+	public override async fromSecret(secret: string): Promise<Services.WIFDataTransferObject> {
+		abort_if(BIP39.compatible(secret), "The given value is BIP39 compliant. Please use [fromMnemonic] instead.");
 
 		return {
 			wif: WIF.encode({
 				// Technically this isn't the WIF version but LSK has none.
 				version: this.configRepository.get<number>("network.constants.slip44"),
-				privateKey: getPrivateAndPublicKeyFromPassphrase(secret).privateKey.toString("hex"),
+				privateKey: getPrivateAndPublicKeyFromPassphrase(secret).privateKey.toString("hex").substring(0, 64),
 				compressed: true,
 			}),
 		};

--- a/packages/sdk-lsk/test/fixtures/identity.ts
+++ b/packages/sdk-lsk/test/fixtures/identity.ts
@@ -11,14 +11,3 @@ export const identity = {
 	multiSignatureAddress: undefined,
 	multiSignaturePublicKey: undefined,
 };
-
-export const identityByLocale = {
-	french: {
-		wif: "LwUyTS2NXysbDezkTfqhrdUbv7gfSSXQEh3UrLC3sEM6QeASUTMZ",
-		privateKey: "ca6bc86f1ba22a25556fb3db912b24e4dedc39f8031ca7dd8ab3ee49fae2fe45",
-		publicKey: "89e68bd2c10eaa8abdf886a17d8d983c784d8c4ec236beb0acdd4d125470e841",
-		address: "lsk879yhgfq4875sdmasxv543sz85nhh6xyjrtap8",
-		mnemonic:
-			"arbitre dauphin révolte riposter fatigue rotatif exécuter ravager renvoi automne boiser bistouri caneton sélectif chose achat tumulte prospère léger effigie buffle microbe oxyde appareil",
-	},
-};

--- a/packages/sdk-luna/package.json
+++ b/packages/sdk-luna/package.json
@@ -25,7 +25,7 @@
 		"preset": "../../jest.config.js"
 	},
 	"dependencies": {
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-nano/package.json
+++ b/packages/sdk-nano/package.json
@@ -25,7 +25,7 @@
 		"preset": "../../jest.config.js"
 	},
 	"dependencies": {
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-neo/package.json
+++ b/packages/sdk-neo/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"@cityofzion/neon-js": "^4.9.0",
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*"

--- a/packages/sdk-sol/package.json
+++ b/packages/sdk-sol/package.json
@@ -25,7 +25,7 @@
 		"preset": "../../jest.config.js"
 	},
 	"dependencies": {
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-trx/package.json
+++ b/packages/sdk-trx/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"@ledgerhq/hw-app-trx": "^6.3.0",
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-xlm/package.json
+++ b/packages/sdk-xlm/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"@ledgerhq/hw-app-str": "^6.3.0",
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-xrp/package.json
+++ b/packages/sdk-xrp/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"@ledgerhq/hw-app-xrp": "^6.3.0",
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk-zil/package.json
+++ b/packages/sdk-zil/package.json
@@ -25,7 +25,7 @@
 		"preset": "../../jest.config.js"
 	},
 	"dependencies": {
-		"@payvo/cryptography": "^1.1.4",
+		"@payvo/cryptography": "^1.1.5",
 		"@payvo/helpers": "^1.1.1",
 		"@payvo/intl": "^1.0.1",
 		"@payvo/sdk": "workspace:*",

--- a/packages/sdk/source/services/shared.contract.ts
+++ b/packages/sdk/source/services/shared.contract.ts
@@ -8,7 +8,6 @@ export interface IdentityLevels {
 
 export interface IdentityOptions {
 	bip39?: boolean;
-	bip39Locale?: string;
 	bip44?: IdentityLevels;
 	bip44Legacy?: IdentityLevels;
 	bip49?: IdentityLevels;


### PR DESCRIPTION
The `fromSecret` methods are intended to be used with BIP39 incompatible values. Introducing a parameter such as `bip39Locale` leaks details about the input and opens up a whole slew of anti-patterns to be introduced. The `BIP39.compatible` method will check the input against each language without `fromSecret` leaking any details about what data it treats as valid. This reduces the API and error surface for clients.