### PR TITLE
fix(lsk): check against valid signatures to determine if a signature is needed in `PendingMultiSignatureTransaction#needsWalletSignature`

### DIFF
--- a/packages/sdk-lsk/source/multi-signature.transaction.ts
+++ b/packages/sdk-lsk/source/multi-signature.transaction.ts
@@ -58,10 +58,6 @@ export class PendingMultiSignatureTransaction {
 			return false;
 		}
 
-		if (this.isMultiSignatureRegistration() && this.isMultiSignatureReady({ excludeFinal: true })) {
-			return this.#transaction.senderPublicKey === publicKey && this.needsFinalSignature();
-		}
-
 		if (![...this.#multiSignature.mandatoryKeys, ...this.#multiSignature.optionalKeys].includes(publicKey)) {
 			return false;
 		}


### PR DESCRIPTION
Lookup directly in valid multisignatures to determine if a signature is needed by public key, and ignore unnecessary checks for final signature and sender public key.