### PR TITLE
refactor: make `MultiSignatureService#getValidMultiSignatures` private

### DIFF
--- a/packages/sdk-ark/source/multi-signature.service.test.ts
+++ b/packages/sdk-ark/source/multi-signature.service.test.ts
@@ -166,12 +166,6 @@ describe("MultiSignatureService", () => {
 		expect(subject.needsFinalSignature(transaction)).toBeTrue();
 	});
 
-	test("#getValidMultiSignatures", async () => {
-		const transaction = (await createService(SignedTransactionData)).configure("123", { signatures: [] });
-
-		expect(subject.getValidMultiSignatures(transaction)).toEqual([]);
-	});
-
 	test("#remainingSignatureCount", async () => {
 		const transaction = (await createService(SignedTransactionData)).configure("123", {
 			signatures: [],

--- a/packages/sdk-ark/source/multi-signature.service.ts
+++ b/packages/sdk-ark/source/multi-signature.service.ts
@@ -126,11 +126,6 @@ export class MultiSignatureService extends Services.AbstractMultiSignatureServic
 	}
 
 	/** @inheritdoc */
-	public override getValidMultiSignatures(transaction: Contracts.SignedTransactionData): string[] {
-		return new PendingMultiSignatureTransaction(transaction.data()).getValidMultiSignatures();
-	}
-
-	/** @inheritdoc */
 	public override remainingSignatureCount(transaction: Contracts.SignedTransactionData): number {
 		return new PendingMultiSignatureTransaction(transaction.data()).remainingSignatureCount();
 	}

--- a/packages/sdk-lsk/source/multi-signature.service.test.ts
+++ b/packages/sdk-lsk/source/multi-signature.service.test.ts
@@ -106,7 +106,6 @@ describe("MultiSignatureService", () => {
 		expect(musig.isMultiSignatureReady(transaction1)).toBeFalse();
 		expect(musig.needsSignatures(transaction1)).toBeTrue();
 		expect(musig.needsAllSignatures(transaction1)).toBeTrue();
-		expect(musig.getValidMultiSignatures(transaction1)).toEqual([wallet1.publicKey]);
 		expect(musig.remainingSignatureCount(transaction1)).toBe(1);
 		expect(musig.needsWalletSignature(transaction1, wallet1.publicKey)).toBeFalse();
 		expect(musig.needsWalletSignature(transaction1, wallet2.publicKey)).toBeTrue();
@@ -129,7 +128,6 @@ describe("MultiSignatureService", () => {
 		expect(musig.isMultiSignatureReady(transaction2)).toBeTrue();
 		expect(musig.needsSignatures(transaction2)).toBeFalse();
 		expect(musig.needsAllSignatures(transaction2)).toBeFalse();
-		expect(musig.getValidMultiSignatures(transaction2)).toEqual([wallet1.publicKey, wallet2.publicKey]);
 		expect(musig.remainingSignatureCount(transaction2)).toBe(0);
 		expect(musig.needsWalletSignature(transaction2, wallet1.publicKey)).toBeFalse();
 		expect(musig.needsWalletSignature(transaction2, wallet2.publicKey)).toBeFalse();

--- a/packages/sdk-lsk/source/multi-signature.service.ts
+++ b/packages/sdk-lsk/source/multi-signature.service.ts
@@ -125,11 +125,6 @@ export class MultiSignatureService extends Services.AbstractMultiSignatureServic
 	}
 
 	/** @inheritdoc */
-	public override getValidMultiSignatures(transaction: Contracts.SignedTransactionData): string[] {
-		return new PendingMultiSignatureTransaction(transaction.data()).getValidMultiSignatures();
-	}
-
-	/** @inheritdoc */
 	public override remainingSignatureCount(transaction: Contracts.SignedTransactionData): number {
 		return new PendingMultiSignatureTransaction(transaction.data()).remainingSignatureCount();
 	}

--- a/packages/sdk-lsk/source/multi-signature.transaction.test.ts
+++ b/packages/sdk-lsk/source/multi-signature.transaction.test.ts
@@ -200,61 +200,6 @@ describe("#needsFinalSignature", () => {
 	});
 });
 
-describe("#getValidMultiSignatures", () => {
-	it("should return empty array if it is not a multi signature transaction", () => {
-		expect(
-			new PendingMultiSignatureTransaction({ ...transfer1, signatures: undefined }).getValidMultiSignatures(),
-		).toMatchInlineSnapshot("Array []");
-	});
-
-	it("should return empty array if the transaction has no signatures yet", () => {
-		expect(
-			new PendingMultiSignatureTransaction({ ...transfer1, signatures: [] }).getValidMultiSignatures(),
-		).toMatchInlineSnapshot("Array []");
-	});
-
-	it("should verify", () => {
-		expect(new PendingMultiSignatureTransaction(transfer1).getValidMultiSignatures()).toEqual([
-			"5948cc0565a3e9320c7442cecb62acdc92b428a0da504c52afb3e84a025d221f",
-		]);
-
-		expect(new PendingMultiSignatureTransaction(transfer2).getValidMultiSignatures()).toEqual([
-			"5948cc0565a3e9320c7442cecb62acdc92b428a0da504c52afb3e84a025d221f",
-			"a3c22fd67483ae07134c93224384dac7206c40b1b7a14186dd2d3f0dcc8234ff",
-		]);
-
-		expect(new PendingMultiSignatureTransaction(register1).getValidMultiSignatures()).toMatchInlineSnapshot(
-			"Array []",
-		);
-		expect(new PendingMultiSignatureTransaction(register2).getValidMultiSignatures()).toEqual([
-			"a3c22fd67483ae07134c93224384dac7206c40b1b7a14186dd2d3f0dcc8234ff",
-		]);
-
-		expect(new PendingMultiSignatureTransaction(register3).getValidMultiSignatures()).toEqual([
-			"5948cc0565a3e9320c7442cecb62acdc92b428a0da504c52afb3e84a025d221f",
-			"a3c22fd67483ae07134c93224384dac7206c40b1b7a14186dd2d3f0dcc8234ff",
-		]);
-
-		expect(
-			new PendingMultiSignatureTransaction({
-				...register3,
-				asset: {
-					...register3.asset,
-					optionalKeys: ["008a3d0b5015cc106053e3f871e471cb607db738662790b5d6917abe02232af3"],
-				},
-
-				multiSignature: {
-					...register3.multiSignature,
-					optionalKeys: ["008a3d0b5015cc106053e3f871e471cb607db738662790b5d6917abe02232af3"],
-				},
-			}).getValidMultiSignatures(),
-		).toEqual([
-			"5948cc0565a3e9320c7442cecb62acdc92b428a0da504c52afb3e84a025d221f",
-			"a3c22fd67483ae07134c93224384dac7206c40b1b7a14186dd2d3f0dcc8234ff",
-		]);
-	});
-});
-
 test("#remainingSignatureCount", () => {
 	expect(new PendingMultiSignatureTransaction(transfer1).remainingSignatureCount()).toBe(1);
 	expect(new PendingMultiSignatureTransaction(transfer2).remainingSignatureCount()).toBe(0);

--- a/packages/sdk-lsk/source/multi-signature.transaction.ts
+++ b/packages/sdk-lsk/source/multi-signature.transaction.ts
@@ -42,11 +42,11 @@ export class PendingMultiSignatureTransaction {
 			return this.needsAllSignatures();
 		}
 
-		return this.getValidMultiSignatures().length < this.#multiSignature.numberOfSignatures;
+		return this.#getValidMultiSignatures().length < this.#multiSignature.numberOfSignatures;
 	}
 
 	public needsAllSignatures(): boolean {
-		return this.getValidMultiSignatures().length < this.#multiSignature.mandatoryKeys.length;
+		return this.#getValidMultiSignatures().length < this.#multiSignature.mandatoryKeys.length;
 	}
 
 	public needsWalletSignature(publicKey: string): boolean {
@@ -66,7 +66,7 @@ export class PendingMultiSignatureTransaction {
 			return false;
 		}
 
-		return !this.getValidMultiSignatures().includes(publicKey);
+		return !this.#getValidMultiSignatures().includes(publicKey);
 	}
 
 	public needsFinalSignature(): boolean {
@@ -81,7 +81,18 @@ export class PendingMultiSignatureTransaction {
 		return this.#transaction.signatures.filter(Boolean).length !== this.#multiSignature.numberOfSignatures + 1;
 	}
 
-	public getValidMultiSignatures(): string[] {
+	public remainingSignatureCount(): number {
+		let numberOfSignatures: number = this.#multiSignature.numberOfSignatures;
+
+		if (this.isMultiSignatureRegistration()) {
+			numberOfSignatures =
+				this.#multiSignature.mandatoryKeys.length + this.#multiSignature.optionalKeys.length + 1;
+		}
+
+		return numberOfSignatures - this.#transaction.signatures.filter(Boolean).length;
+	}
+
+	#getValidMultiSignatures(): string[] {
 		if (!this.isMultiSignature()) {
 			return [];
 		}
@@ -126,16 +137,5 @@ export class PendingMultiSignatureTransaction {
 		}
 
 		return convertBufferList(result);
-	}
-
-	public remainingSignatureCount(): number {
-		let numberOfSignatures: number = this.#multiSignature.numberOfSignatures;
-
-		if (this.isMultiSignatureRegistration()) {
-			numberOfSignatures =
-				this.#multiSignature.mandatoryKeys.length + this.#multiSignature.optionalKeys.length + 1;
-		}
-
-		return numberOfSignatures - this.#transaction.signatures.filter(Boolean).length;
 	}
 }

--- a/packages/sdk/source/services/multi-signature.contract.ts
+++ b/packages/sdk/source/services/multi-signature.contract.ts
@@ -109,15 +109,6 @@ export interface MultiSignatureService {
 	needsFinalSignature(transaction: SignedTransactionData): boolean;
 
 	/**
-	 * Retrieve all signatures that are valid according to schnorr verification.
-	 *
-	 * @param {SignedTransactionData} transaction
-	 * @returns {string[]}
-	 * @memberof MultiSignatureService
-	 */
-	getValidMultiSignatures(transaction: SignedTransactionData): string[];
-
-	/**
 	 * Determine how many signatures are missing.
 	 *
 	 * @param {SignedTransactionData} transaction

--- a/packages/sdk/source/services/multi-signature.service.ts
+++ b/packages/sdk/source/services/multi-signature.service.ts
@@ -50,10 +50,6 @@ export class AbstractMultiSignatureService implements MultiSignatureService {
 		throw new NotImplemented(this.constructor.name, this.needsFinalSignature.name);
 	}
 
-	public getValidMultiSignatures(transaction: SignedTransactionData): string[] {
-		throw new NotImplemented(this.constructor.name, this.getValidMultiSignatures.name);
-	}
-
 	public remainingSignatureCount(transaction: SignedTransactionData): number {
 		throw new NotImplemented(this.constructor.name, this.remainingSignatureCount.name);
 	}


### PR DESCRIPTION
This method doesn't apply to all coins so usage of this on the client-side can lead to misleading behaviours.