### PR TITLE
refactor: remove redundant statements in `ClientService` after deleting identifiers from query

### DIFF
--- a/packages/sdk-ark/source/client.service.test.ts
+++ b/packages/sdk-ark/source/client.service.test.ts
@@ -72,27 +72,6 @@ describe("ClientService", () => {
 				expect(result).toBeObject();
 				expect(result.items()[0]).toBeInstanceOf(ConfirmedTransactionData);
 			});
-
-			it("multiple addresses", async () => {
-				nock(/.+/)
-					.get("/api/transactions")
-					.query({
-						page: "0",
-						address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8,DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5",
-					})
-					.reply(200, await require(`../test/fixtures/client/transactions.json`));
-
-				const result = await subject.transactions({
-					identifiers: [
-						{ type: "address", value: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" },
-						{ type: "address", value: "DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5" },
-					],
-					cursor: "0",
-				});
-
-				expect(result).toBeObject();
-				expect(result.items()[0]).toBeInstanceOf(ConfirmedTransactionData);
-			});
 		});
 
 		describe("should work with Core 3.0", () => {
@@ -119,23 +98,6 @@ describe("ClientService", () => {
 
 				const result = await subject.transactions({
 					identifiers: [{ type: "address", value: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" }],
-				});
-
-				expect(result).toBeObject();
-				expect(result.items()[0]).toBeInstanceOf(ConfirmedTransactionData);
-			});
-
-			it("multiple addresses", async () => {
-				nock(/.+/)
-					.get("/api/transactions")
-					.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8,DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5" })
-					.reply(200, await require(`../test/fixtures/client/transactions.json`));
-
-				const result = await subject.transactions({
-					identifiers: [
-						{ type: "address", value: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" },
-						{ type: "address", value: "DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5" },
-					],
 				});
 
 				expect(result).toBeObject();

--- a/packages/sdk-ark/source/client.service.test.ts
+++ b/packages/sdk-ark/source/client.service.test.ts
@@ -72,6 +72,27 @@ describe("ClientService", () => {
 				expect(result).toBeObject();
 				expect(result.items()[0]).toBeInstanceOf(ConfirmedTransactionData);
 			});
+
+			it("multiple addresses", async () => {
+				nock(/.+/)
+					.get("/api/transactions")
+					.query({
+						page: "0",
+						address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8,DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5",
+					})
+					.reply(200, await require(`../test/fixtures/client/transactions.json`));
+
+				const result = await subject.transactions({
+					identifiers: [
+						{ type: "address", value: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" },
+						{ type: "address", value: "DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5" },
+					],
+					cursor: "0",
+				});
+
+				expect(result).toBeObject();
+				expect(result.items()[0]).toBeInstanceOf(ConfirmedTransactionData);
+			});
 		});
 
 		describe("should work with Core 3.0", () => {
@@ -98,6 +119,23 @@ describe("ClientService", () => {
 
 				const result = await subject.transactions({
 					identifiers: [{ type: "address", value: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" }],
+				});
+
+				expect(result).toBeObject();
+				expect(result.items()[0]).toBeInstanceOf(ConfirmedTransactionData);
+			});
+
+			it("multiple addresses", async () => {
+				nock(/.+/)
+					.get("/api/transactions")
+					.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8,DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5" })
+					.reply(200, await require(`../test/fixtures/client/transactions.json`));
+
+				const result = await subject.transactions({
+					identifiers: [
+						{ type: "address", value: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" },
+						{ type: "address", value: "DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5" },
+					],
 				});
 
 				expect(result).toBeObject();

--- a/packages/sdk-ark/source/client.service.ts
+++ b/packages/sdk-ark/source/client.service.ts
@@ -203,31 +203,17 @@ export class ClientService extends Services.AbstractClientService {
 			}
 		}
 
-		if (this.#isLegacy()) {
-			const identifiers: Services.WalletIdentifier[] | undefined =
-				// @ts-ignore
-				body.identifiers as Services.WalletIdentifier[];
-			if (identifiers) {
-				if (!body.recipientId && !body.senderId) {
-					result.body.addresses = identifiers.map(({ value }) => value);
-				}
+		if (body.identifiers) {
+			const address = body.identifiers[0].value;
 
-				// @ts-ignore
-				delete body.identifiers;
+			if (this.#isLegacy()) {
+				result.body.addresses = [address];
+			} else {
+				result.searchParams.address = address;
 			}
-		} else {
+
 			// @ts-ignore
-			const addresses: Services.WalletIdentifier[] | undefined = body.identifiers as Services.WalletIdentifier[];
-
-			if (Array.isArray(addresses)) {
-				result.searchParams.address = addresses.map(({ value }) => value).join(",");
-
-				// @ts-ignore
-				delete body.identifiers;
-			}
-
-			result.searchParams = dotify({ ...result.searchParams, ...result.body });
-			result.body = null;
+			delete body.identifiers;
 		}
 
 		// @ts-ignore
@@ -303,6 +289,11 @@ export class ClientService extends Services.AbstractClientService {
 				// @ts-ignore
 				delete body.type;
 			}
+		}
+
+		if (! this.#isLegacy()) {
+			result.searchParams = dotify({ ...result.searchParams, ...result.body });
+			result.body = null;
 		}
 
 		return result;

--- a/packages/sdk-ark/source/client.service.ts
+++ b/packages/sdk-ark/source/client.service.ts
@@ -204,12 +204,12 @@ export class ClientService extends Services.AbstractClientService {
 		}
 
 		if (body.identifiers) {
-			const address = body.identifiers[0].value;
+			const identifiers: Services.WalletIdentifier[] = body.identifiers;
 
 			if (this.#isLegacy()) {
-				result.body.addresses = [address];
+				result.body.addresses = identifiers.map(({ value }) => value);
 			} else {
-				result.searchParams.address = address;
+				result.searchParams.address = identifiers.map(({ value }) => value).join(",");
 			}
 
 			// @ts-ignore

--- a/packages/sdk-lsk/source/client.service.ts
+++ b/packages/sdk-lsk/source/client.service.ts
@@ -175,16 +175,14 @@ export class ClientService extends Services.AbstractClientService {
 
 		// LSK doesn't support bulk lookups so we will simply use the first address.
 		if (searchParams.identifiers) {
-			if (!searchParams.recipientId) {
-				const value = searchParams.identifiers[0].value;
+			const value = searchParams.identifiers[0].value;
 
-				if (!searchParams.type || searchParams.type === "transfer") {
-					// @ts-ignore - This field doesn't exist on the interface but is needed.
-					searchParams.address = value;
-				} else {
-					// @ts-ignore - This field doesn't exist on the interface but is needed.
-					searchParams.senderAddress = value;
-				}
+			if (!searchParams.type || searchParams.type === "transfer") {
+				// @ts-ignore - This field doesn't exist on the interface but is needed.
+				searchParams.address = value;
+			} else {
+				// @ts-ignore - This field doesn't exist on the interface but is needed.
+				searchParams.senderAddress = value;
 			}
 
 			delete searchParams.identifiers;


### PR DESCRIPTION
after [removing identifiers](https://github.com/PayvoHQ/profiles/pull/93) from query, we don't have the identifiers for [sent](https://github.com/PayvoHQ/profiles/blob/master/source/transaction-index.ts#L34) or [received](https://github.com/PayvoHQ/profiles/blob/master/source/transaction-index.ts#L41) method, so there is no need to check `recipientId`/`senderId` before set the address

also, there is no more multiple addresses in identifiers, [just single address](https://github.com/PayvoHQ/profiles/blob/master/source/transaction-index.ts#L24-L28)