### PR TITLE
refactor: introduce `LedgerTransportFactory`

### DIFF
--- a/packages/ark/package.json
+++ b/packages/ark/package.json
@@ -33,7 +33,6 @@
 		"@arkecosystem/crypto": "^3.0.5",
 		"@arkecosystem/crypto-identities": "^1.2.0",
 		"@arkecosystem/ledger-transport": "^2.0.0",
-		"@ledgerhq/hw-transport-node-hid-singleton": "^6.11.2",
 		"@payvo/sdk": "workspace:*",
 		"@payvo/sdk-cryptography": "workspace:*",
 		"@payvo/sdk-helpers": "workspace:*",

--- a/packages/ark/source/fee.service.test.ts
+++ b/packages/ark/source/fee.service.test.ts
@@ -134,6 +134,7 @@ describe("FeeService", () => {
 						Services.AbstractDataTransferObjectService,
 					);
 					container.singleton(IoC.BindingType.KeyPairService, KeyPairService);
+					container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});
 					container.singleton(IoC.BindingType.LedgerService, LedgerService);
 					container.singleton(IoC.BindingType.PublicKeyService, PublicKeyService);
 					container.singleton(IoC.BindingType.MultiSignatureService, MultiSignatureService);

--- a/packages/ark/source/ledger.service.test.ts
+++ b/packages/ark/source/ledger.service.test.ts
@@ -2,7 +2,7 @@ import "jest-extended";
 
 import { jest } from "@jest/globals";
 import { Address } from "@arkecosystem/crypto-identities";
-import { IoC, Services, Test } from "@payvo/sdk";
+import { IoC, Services } from "@payvo/sdk";
 import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
 import nock from "nock";
 
@@ -26,10 +26,13 @@ const createMockService = async (record: string): Promise<LedgerService> => {
 			WalletData,
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
+		container.constant(
+			IoC.BindingType.LedgerTransportFactory,
+			async () => await openTransportReplayer(RecordStore.fromString(record)),
+		);
 	});
 
-	const fromString = RecordStore.fromString(record);
-	await transport.connect(await openTransportReplayer(fromString));
+	await transport.connect();
 
 	return transport;
 };

--- a/packages/ark/source/ledger.service.ts
+++ b/packages/ark/source/ledger.service.ts
@@ -17,17 +17,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 	#ledger!: Services.LedgerTransport;
 	#transport!: ARKTransport;
 
-	public override async connect(transport: Services.LedgerTransport): Promise<void> {
-		try {
-			this.#ledger = await transport.open();
-		} catch (error) {
-			if (transport.constructor.name === "TransportReplayer") {
-				this.#ledger = transport;
-			} else {
-				throw error;
-			}
-		}
-
+	public override async connect(): Promise<void> {
+		this.#ledger = await this.ledgerTransportFactory();
 		this.#transport = new ARKTransport(this.#ledger);
 	}
 

--- a/packages/ark/source/multi-signature.service.test.ts
+++ b/packages/ark/source/multi-signature.service.test.ts
@@ -33,6 +33,7 @@ beforeAll(async () => {
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(BindingType.MultiSignatureSigner, MultiSignatureSigner);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);
+		container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});
 		container.singleton(IoC.BindingType.LedgerService, LedgerService);
 		container.singleton(IoC.BindingType.PublicKeyService, PublicKeyService);
 	});

--- a/packages/ark/source/multi-signature.signer.ts
+++ b/packages/ark/source/multi-signature.signer.ts
@@ -1,6 +1,5 @@
 import { Managers, Transactions, Interfaces, Identities, Enums, Utils } from "@arkecosystem/crypto";
 import { Contracts, IoC, Services, Signatories } from "@payvo/sdk";
-import LedgerTransportNodeHID from "@ledgerhq/hw-transport-node-hid-singleton";
 
 import { BindingType } from "./coin.contract";
 import { MultiSignatureAsset, MultiSignatureTransaction } from "./multi-signature.contract";
@@ -167,7 +166,7 @@ export class MultiSignatureSigner {
 		signatory: Signatories.Signatory,
 		excludeMultiSignature = false,
 	): Promise<string> {
-		await this.ledgerService.connect(LedgerTransportNodeHID);
+		await this.ledgerService.connect();
 
 		const signature = await this.ledgerService.signTransaction(
 			signatory.signingKey(),

--- a/packages/ark/source/transaction.service.test.ts
+++ b/packages/ark/source/transaction.service.test.ts
@@ -1,7 +1,7 @@
 import "jest-extended";
 
 import { Transactions } from "@arkecosystem/crypto";
-import { IoC, Services, Signatories, Test } from "@payvo/sdk";
+import { IoC, Services, Signatories } from "@payvo/sdk";
 import nock from "nock";
 
 import { createService, requireModule } from "../test/mocking";
@@ -38,6 +38,7 @@ beforeAll(async () => {
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);
+		container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});
 		container.singleton(IoC.BindingType.LedgerService, LedgerService);
 		container.singleton(IoC.BindingType.PublicKeyService, PublicKeyService);
 		container.singleton(IoC.BindingType.MultiSignatureService, MultiSignatureService);

--- a/packages/ark/source/transaction.service.ts
+++ b/packages/ark/source/transaction.service.ts
@@ -2,7 +2,6 @@ import { Identities, Interfaces, Transactions } from "@arkecosystem/crypto";
 import { Contracts, Exceptions, Helpers, IoC, Services, Signatories } from "@payvo/sdk";
 import { BIP39 } from "@payvo/sdk-cryptography";
 import { BigNumber } from "@payvo/sdk-helpers";
-import LedgerTransportNodeHID from "@ledgerhq/hw-transport-node-hid-singleton";
 
 import { BindingType } from "./coin.contract";
 import { applyCryptoConfiguration } from "./config";
@@ -251,7 +250,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		}
 
 		if (input.signatory.actsWithLedger()) {
-			await this.ledgerService.connect(LedgerTransportNodeHID);
+			await this.ledgerService.connect();
 
 			senderPublicKey = await this.ledgerService.getPublicKey(input.signatory.signingKey());
 			address = (await this.addressService.fromPublicKey(senderPublicKey)).address;

--- a/packages/atom/source/ledger.service.test.ts
+++ b/packages/atom/source/ledger.service.test.ts
@@ -4,7 +4,7 @@ import { IoC, Services } from "@payvo/sdk";
 import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
 
 import { ledger } from "../test/fixtures/ledger";
-import { createService, requireModule } from "../test/mocking";
+import { createService } from "../test/mocking";
 import { AddressService } from "./address.service";
 import { ClientService } from "./client.service";
 import { LedgerService } from "./ledger.service";
@@ -23,9 +23,13 @@ const createMockService = async (record: string) => {
 			WalletData,
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
+		container.constant(
+			IoC.BindingType.LedgerTransportFactory,
+			async () => await openTransportReplayer(RecordStore.fromString(record)),
+		);
 	});
 
-	await transport.connect(await openTransportReplayer(RecordStore.fromString(record)));
+	await transport.connect();
 
 	return transport;
 };

--- a/packages/atom/source/ledger.service.ts
+++ b/packages/atom/source/ledger.service.ts
@@ -7,17 +7,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;
 	#transport!: Cosmos;
 
-	public override async connect(transport: Services.LedgerTransport): Promise<void> {
-		try {
-			this.#ledger = await transport.create();
-		} catch (error) {
-			if (transport.constructor.name === "TransportReplayer") {
-				this.#ledger = transport;
-			} else {
-				throw error;
-			}
-		}
-
+	public override async connect(): Promise<void> {
+		this.#ledger = await this.ledgerTransportFactory();
 		this.#transport = new Cosmos.default(this.#ledger);
 	}
 

--- a/packages/btc/package.json
+++ b/packages/btc/package.json
@@ -31,7 +31,6 @@
 	},
 	"dependencies": {
 		"@ledgerhq/hw-app-btc": "^6.12.1",
-		"@ledgerhq/hw-transport-node-hid-singleton": "^6.11.2",
 		"@payvo/sdk": "workspace:*",
 		"@payvo/sdk-cryptography": "workspace:*",
 		"@payvo/sdk-helpers": "workspace:*",

--- a/packages/btc/source/coin.provider.ts
+++ b/packages/btc/source/coin.provider.ts
@@ -2,13 +2,10 @@ import { IoC } from "@payvo/sdk";
 import { BindingType } from "./constants";
 
 import { AddressFactory } from "./address.factory";
-import LedgerTransportNodeHID from "@ledgerhq/hw-transport-node-hid-singleton";
 
 export class ServiceProvider extends IoC.AbstractServiceProvider {
 	public override async make(container: IoC.Container): Promise<void> {
 		container.singleton(BindingType.AddressFactory, AddressFactory);
-		// @ts-ignore
-		container.singleton(BindingType.LedgerTransport, LedgerTransportNodeHID.default);
 
 		return this.compose(container);
 	}

--- a/packages/btc/source/constants.ts
+++ b/packages/btc/source/constants.ts
@@ -1,4 +1,3 @@
 export const BindingType = {
 	AddressFactory: Symbol.for("BTC<AddressFactory>"),
-	LedgerTransport: Symbol.for("BTC<LedgerTransport>"),
 };

--- a/packages/btc/source/ledger.service.test.ts
+++ b/packages/btc/source/ledger.service.test.ts
@@ -23,9 +23,13 @@ const createMockService = async (record: string) => {
 			WalletData,
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
+		container.constant(
+			IoC.BindingType.LedgerTransportFactory,
+			async () => await openTransportReplayer(RecordStore.fromString(record)),
+		);
 	});
 
-	await transport.connect(await openTransportReplayer(RecordStore.fromString(record)));
+	await transport.connect();
 
 	return transport;
 };

--- a/packages/btc/source/ledger.service.ts
+++ b/packages/btc/source/ledger.service.ts
@@ -16,17 +16,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;
 	#transport!: Bitcoin;
 
-	public override async connect(transport: Services.LedgerTransport): Promise<void> {
-		try {
-			this.#ledger = await transport.create();
-		} catch (error) {
-			if (transport.constructor.name === "TransportReplayer") {
-				this.#ledger = transport;
-			} else {
-				throw error;
-			}
-		}
-
+	public override async connect(): Promise<void> {
+		this.#ledger = await this.ledgerTransportFactory();
 		// @ts-ignore
 		this.#transport = new Bitcoin.default(this.#ledger);
 	}

--- a/packages/btc/source/transaction.service.ledger.test.ts
+++ b/packages/btc/source/transaction.service.ledger.test.ts
@@ -50,6 +50,7 @@ const configureMock = (record: string): TransactionService =>
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.ExtendedPublicKeyService, ExtendedPublicKeyService);
 		container.singleton(IoC.BindingType.FeeService, FeeService);
+		container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});
 		container.singleton(IoC.BindingType.LedgerService, LedgerService);
 		container.singleton(BindingType.AddressFactory, AddressFactory);
 

--- a/packages/btc/source/transaction.service.test.ts
+++ b/packages/btc/source/transaction.service.test.ts
@@ -37,9 +37,12 @@ beforeEach(async () => {
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.ExtendedPublicKeyService, ExtendedPublicKeyService);
 		container.singleton(IoC.BindingType.FeeService, FeeService);
+		container.constant(
+			IoC.BindingType.LedgerTransportFactory,
+			async () => await openTransportReplayer(RecordStore.fromString("")),
+		);
 		container.singleton(IoC.BindingType.LedgerService, LedgerService);
 		container.singleton(BindingType.AddressFactory, AddressFactory);
-		container.constant(BindingType.LedgerTransport, await openTransportReplayer(RecordStore.fromString("")));
 	});
 });
 

--- a/packages/btc/source/transaction.service.ts
+++ b/packages/btc/source/transaction.service.ts
@@ -15,13 +15,13 @@ import { LedgerService } from "./ledger.service";
 const runWithLedgerConnectionIfNeeded = async (
 	signatory: Signatories.Signatory,
 	ledgerService: LedgerService,
-	transport: Services.LedgerTransport,
 	callback: () => Promise<Contracts.SignedTransactionData>,
 ): Promise<Contracts.SignedTransactionData> => {
 	try {
 		if (signatory.actsWithLedger()) {
-			await ledgerService.connect(transport);
+			await ledgerService.connect();
 		}
+
 		return await callback();
 	} finally {
 		if (signatory.actsWithLedger()) {
@@ -40,9 +40,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	@IoC.inject(IoC.BindingType.FeeService)
 	private readonly feeService!: Services.FeeService;
-
-	@IoC.inject(BindingType.LedgerTransport)
-	private readonly transport!: Services.LedgerTransport;
 
 	public override async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		if (!input.signatory.actsWithMultiSignature() && input.signatory.signingKey() === undefined) {
@@ -79,7 +76,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 			);
 		}
 
-		return await runWithLedgerConnectionIfNeeded(input.signatory, this.ledgerService, this.transport, async () => {
+		return await runWithLedgerConnectionIfNeeded(input.signatory, this.ledgerService, async () => {
 			const levels = this.addressFactory.getLevel(identityOptions);
 
 			const network = getNetworkConfig(this.configRepository);

--- a/packages/dot/source/ledger.service.test.ts
+++ b/packages/dot/source/ledger.service.test.ts
@@ -23,9 +23,13 @@ const createMockService = async (record: string) => {
 			WalletData,
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
+		container.constant(
+			IoC.BindingType.LedgerTransportFactory,
+			async () => await openTransportReplayer(RecordStore.fromString(record)),
+		);
 	});
 
-	await transport.connect(await openTransportReplayer(RecordStore.fromString(record)));
+	await transport.connect();
 
 	return transport;
 };

--- a/packages/dot/source/ledger.service.ts
+++ b/packages/dot/source/ledger.service.ts
@@ -6,17 +6,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;
 	#transport;
 
-	public override async connect(transport: Services.LedgerTransport): Promise<void> {
-		try {
-			this.#ledger = await transport.create();
-		} catch (error) {
-			if (transport.constructor.name === "TransportReplayer") {
-				this.#ledger = transport;
-			} else {
-				throw error;
-			}
-		}
-
+	public override async connect(): Promise<void> {
+		this.#ledger = await this.ledgerTransportFactory();
 		this.#transport = newPolkadotApp(this.#ledger);
 	}
 

--- a/packages/eos/source/ledger.service.test.ts
+++ b/packages/eos/source/ledger.service.test.ts
@@ -23,9 +23,13 @@ const createMockService = async (record: string) => {
 			WalletData,
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
+		container.constant(
+			IoC.BindingType.LedgerTransportFactory,
+			async () => await openTransportReplayer(RecordStore.fromString(record)),
+		);
 	});
 
-	await transport.connect(await openTransportReplayer(RecordStore.fromString(record)));
+	await transport.connect();
 
 	return transport;
 };

--- a/packages/eos/source/ledger.service.ts
+++ b/packages/eos/source/ledger.service.ts
@@ -5,16 +5,8 @@ import { BIP44 } from "@payvo/sdk-cryptography";
 export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;
 
-	public override async connect(transport: Services.LedgerTransport): Promise<void> {
-		try {
-			this.#ledger = await transport.create();
-		} catch (error) {
-			if (transport.constructor.name === "TransportReplayer") {
-				this.#ledger = transport;
-			} else {
-				throw error;
-			}
-		}
+	public override async connect(): Promise<void> {
+		this.#ledger = await this.ledgerTransportFactory();
 	}
 
 	@IoC.preDestroy()

--- a/packages/eth/source/ledger.service.test.ts
+++ b/packages/eth/source/ledger.service.test.ts
@@ -23,9 +23,13 @@ const createMockService = async (record: string) => {
 			WalletData,
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
+		container.constant(
+			IoC.BindingType.LedgerTransportFactory,
+			async () => await openTransportReplayer(RecordStore.fromString(record)),
+		);
 	});
 
-	await transport.connect(await openTransportReplayer(RecordStore.fromString(record)));
+	await transport.connect();
 
 	return transport;
 };

--- a/packages/eth/source/ledger.service.ts
+++ b/packages/eth/source/ledger.service.ts
@@ -6,17 +6,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;
 	#transport!: Ethereum;
 
-	public override async connect(transport: Services.LedgerTransport): Promise<void> {
-		try {
-			this.#ledger = await transport.open();
-		} catch (error) {
-			if (transport.constructor.name === "TransportReplayer") {
-				this.#ledger = transport;
-			} else {
-				throw error;
-			}
-		}
-
+	public override async connect(): Promise<void> {
+		this.#ledger = await this.ledgerTransportFactory();
 		// @ts-ignore
 		this.#transport = new Ethereum.default(this.#ledger);
 	}

--- a/packages/lsk/package.json
+++ b/packages/lsk/package.json
@@ -30,7 +30,6 @@
 		"preset": "../../jest.config.js"
 	},
 	"dependencies": {
-		"@ledgerhq/hw-transport-node-hid-singleton": "^6.11.2",
 		"@liskhq/lisk-cryptography": "^3.2",
 		"@liskhq/lisk-transactions": "^5.2",
 		"@payvo/sdk": "workspace:*",

--- a/packages/lsk/source/fee.service.test.ts
+++ b/packages/lsk/source/fee.service.test.ts
@@ -39,6 +39,7 @@ beforeEach(async () => {
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);
+		container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});
 		container.singleton(IoC.BindingType.LedgerService, LedgerService);
 		container.singleton(IoC.BindingType.PublicKeyService, PublicKeyService);
 		container.singleton(IoC.BindingType.MultiSignatureService, MultiSignatureService);
@@ -94,6 +95,7 @@ describe("FeeService", () => {
 					Services.AbstractDataTransferObjectService,
 				);
 				container.singleton(IoC.BindingType.KeyPairService, KeyPairService);
+				container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});
 				container.singleton(IoC.BindingType.LedgerService, LedgerService);
 				container.singleton(IoC.BindingType.PublicKeyService, PublicKeyService);
 				container.singleton(IoC.BindingType.MultiSignatureService, MultiSignatureService);

--- a/packages/lsk/source/ledger.service.test.ts
+++ b/packages/lsk/source/ledger.service.test.ts
@@ -54,12 +54,9 @@ describe("connect", () => {
 			container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 			container.singleton(BindingType.AssetSerializer, AssetSerializer);
 			container.singleton(BindingType.TransactionSerializer, TransactionSerializer);
-			container.constant(
-				IoC.BindingType.LedgerTransportFactory,
-				() => {
-					throw new Error("cannot open")
-				},
-			);
+			container.constant(IoC.BindingType.LedgerTransportFactory, () => {
+				throw new Error("cannot open");
+			});
 		});
 
 		await expect(() => transport.connect()).rejects.toThrow();

--- a/packages/lsk/source/ledger.service.ts
+++ b/packages/lsk/source/ledger.service.ts
@@ -16,17 +16,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;
 	#transport!: DposLedger;
 
-	public override async connect(transport: Services.LedgerTransport): Promise<void> {
-		try {
-			this.#ledger = await transport.open();
-		} catch (error) {
-			if (transport.constructor.name === "TransportReplayer") {
-				this.#ledger = transport;
-			} else {
-				throw error;
-			}
-		}
-
+	public override async connect(): Promise<void> {
+		this.#ledger = await this.ledgerTransportFactory();
 		this.#transport = new DposLedger(new CommHandler(this.#ledger));
 	}
 

--- a/packages/lsk/source/multi-signature.service.test.ts
+++ b/packages/lsk/source/multi-signature.service.test.ts
@@ -40,6 +40,7 @@ beforeAll(async () => {
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.FeeService, FeeService);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);
+		container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});
 		container.singleton(IoC.BindingType.LedgerService, LedgerService);
 		container.singleton(IoC.BindingType.PublicKeyService, PublicKeyService);
 		container.singleton(IoC.BindingType.MultiSignatureService, MultiSignatureService);
@@ -59,6 +60,7 @@ beforeAll(async () => {
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.FeeService, FeeService);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);
+		container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});
 		container.singleton(IoC.BindingType.LedgerService, LedgerService);
 		container.singleton(IoC.BindingType.PublicKeyService, PublicKeyService);
 		container.singleton(BindingType.AssetSerializer, AssetSerializer);

--- a/packages/lsk/source/transaction.service.test.ts
+++ b/packages/lsk/source/transaction.service.test.ts
@@ -43,6 +43,7 @@ beforeAll(async () => {
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.FeeService, FeeService);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);
+		container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});
 		container.singleton(IoC.BindingType.LedgerService, LedgerService);
 		container.singleton(IoC.BindingType.PublicKeyService, PublicKeyService);
 		container.singleton(IoC.BindingType.MultiSignatureService, MultiSignatureService);
@@ -62,6 +63,7 @@ beforeAll(async () => {
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
 		container.singleton(IoC.BindingType.FeeService, FeeService);
 		container.singleton(IoC.BindingType.KeyPairService, KeyPairService);
+		container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});
 		container.singleton(IoC.BindingType.LedgerService, LedgerService);
 		container.singleton(IoC.BindingType.PublicKeyService, PublicKeyService);
 		container.singleton(BindingType.AssetSerializer, AssetSerializer);

--- a/packages/neo/source/ledger.service.test.ts
+++ b/packages/neo/source/ledger.service.test.ts
@@ -4,7 +4,7 @@ import { IoC, Services } from "@payvo/sdk";
 import { openTransportReplayer, RecordStore, RecordStoreOptions } from "@ledgerhq/hw-transport-mocker";
 
 import { ledger } from "../test/fixtures/ledger";
-import { createService, requireModule } from "../test/mocking";
+import { createService } from "../test/mocking";
 import { AddressService } from "./address.service";
 import { ClientService } from "./client.service";
 import { LedgerService } from "./ledger.service";
@@ -23,9 +23,13 @@ const createMockService = async (record: string, opts?: RecordStoreOptions) => {
 			WalletData,
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
+		container.constant(
+			IoC.BindingType.LedgerTransportFactory,
+			async () => await openTransportReplayer(RecordStore.fromString(record, opts)),
+		);
 	});
 
-	await transport.connect(await openTransportReplayer(RecordStore.fromString(record, opts)));
+	await transport.connect();
 
 	return transport;
 };

--- a/packages/neo/source/ledger.service.ts
+++ b/packages/neo/source/ledger.service.ts
@@ -6,16 +6,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;
 	#bip44SessionPath = "";
 
-	public override async connect(transport: Services.LedgerTransport): Promise<void> {
-		try {
-			this.#ledger = await transport.create();
-		} catch (error) {
-			if (transport.constructor.name === "TransportReplayer") {
-				this.#ledger = transport;
-			} else {
-				throw error;
-			}
-		}
+	public override async connect(): Promise<void> {
+		this.#ledger = await this.ledgerTransportFactory();
 	}
 
 	@IoC.preDestroy()

--- a/packages/profiles/source/env.models.ts
+++ b/packages/profiles/source/env.models.ts
@@ -1,4 +1,4 @@
-import { Coins, Http } from "@payvo/sdk";
+import { Coins, Http, Services } from "@payvo/sdk";
 
 export type CoinList = Record<string, Coins.CoinBundle>;
 
@@ -13,6 +13,7 @@ export interface EnvironmentOptions {
 	coins: CoinList;
 	storage: string | Storage;
 	httpClient: Http.HttpClient;
+	ledgerTransport?: Services.LedgerTransport;
 	migrations?: Record<string, any>;
 }
 

--- a/packages/sdk/source/coins/coin-factory.ts
+++ b/packages/sdk/source/coins/coin-factory.ts
@@ -36,6 +36,7 @@ export class CoinFactory {
 		container.constant(BindingType.DataTransferObjects, bundle.dataTransferObjects);
 		container.constant(BindingType.Container, container);
 		container.constant(BindingType.HttpClient, options.httpClient);
+		container.constant(BindingType.LedgerTransportFactory, options.ledgerTransportFactory);
 		container.constant(BindingType.Manifest, new Manifest(bundle.manifest));
 		container.constant(BindingType.Network, CoinFactory.#createNetwork(bundle.manifest, configRepository));
 		container.constant(BindingType.NetworkRepository, networkRepository);

--- a/packages/sdk/source/coins/contracts.ts
+++ b/packages/sdk/source/coins/contracts.ts
@@ -9,6 +9,7 @@ import {
 	KeyPairService,
 	KnownWalletService,
 	LedgerService,
+	LedgerTransportFactory,
 	LinkService,
 	MessageService,
 	MultiSignatureService,
@@ -31,6 +32,7 @@ export interface CoinOptions {
 	network: string;
 	networks?: Record<string, NetworkManifest>;
 	httpClient: HttpClient;
+	ledgerTransportFactory?: LedgerTransportFactory;
 }
 
 export interface CoinServices {

--- a/packages/sdk/source/contracts.ts
+++ b/packages/sdk/source/contracts.ts
@@ -72,9 +72,12 @@ export interface WalletData {
 	hasFailed(): boolean;
 }
 
+type LedgerTransport = any;
+
 // @TODO: export those directly from the files and get rid of this whole file
 export {
 	ConfirmedTransactionData,
+	LedgerTransport,
 	MultiPaymentRecipient,
 	RawTransactionData,
 	SignedTransactionData,

--- a/packages/sdk/source/ioc/service-provider.contract.ts
+++ b/packages/sdk/source/ioc/service-provider.contract.ts
@@ -5,20 +5,13 @@ export type ServiceList = Record<string, interfaces.Newable<any>>;
 export const BindingType = {
 	// [Coin] Services
 	AddressService: Symbol.for("Coin<AddressService>"),
-
 	BigNumberService: Symbol.for("Coin<BigNumberService>"),
-
 	ClientService: Symbol.for("Coin<ClientService>"),
-
 	ConfigRepository: Symbol.for("Coin<ConfigRepository>"),
-
 	// [Coin] Internals
 	Container: Symbol.for("Coin<Container>"),
-
 	DataTransferObjectService: Symbol.for("Coin<DataTransferObjectService>"),
-
 	DataTransferObjects: Symbol.for("Coin<DataTransferObjects>"),
-
 	ExtendedAddressService: Symbol.for("Coin<ExtendedAddressService>"),
 	ExtendedPublicKeyService: Symbol.for("Coin<ExtendedPublicKeyService>"),
 	FeeService: Symbol.for("Coin<FeeService>"),
@@ -26,25 +19,30 @@ export const BindingType = {
 	KeyPairService: Symbol.for("Coin<KeyPairService>"),
 	KnownWalletService: Symbol.for("Coin<KnownWalletService>"),
 	LedgerService: Symbol.for("Coin<LedgerService>"),
+	// [Coin] Miscellaneous
+	LedgerTransport: Symbol.for("Coin<LedgerTransport>"),
+
+	LedgerTransportFactory: Symbol.for("Coin<LedgerTransportFactory>"),
+
 	LinkService: Symbol.for("Coin<LinkService>"),
+
 	Manifest: Symbol.for("Coin<Manifest>"),
+
 	MessageService: Symbol.for("Coin<MessageService>"),
+
 	MultiSignatureService: Symbol.for("Coin<MultiSignatureService>"),
+
 	Network: Symbol.for("Coin<Network>"),
+
 	NetworkRepository: Symbol.for("Coin<NetworkRepository>"),
+
 	PrivateKeyService: Symbol.for("Coin<PrivateKeyService>"),
 	PublicKeyService: Symbol.for("Coin<PublicKeyService>"),
-	// [Coin] Miscellaneous
 	ServiceProvider: Symbol.for("Coin<ServiceProvider>"),
-
 	Services: Symbol.for("Coin<Services>"),
-
 	SignatoryService: Symbol.for("Coin<SignatoryService>"),
-
 	Specification: Symbol.for("Coin<Specification>"),
-
 	TransactionService: Symbol.for("Coin<TransactionService>"),
-
 	WIFService: Symbol.for("Coin<WIFService>"),
 	WalletDiscoveryService: Symbol.for("Coin<WalletDiscoveryService>"),
 };

--- a/packages/sdk/source/services/ledger.contract.ts
+++ b/packages/sdk/source/services/ledger.contract.ts
@@ -1,16 +1,12 @@
 import { WalletData } from "../contracts";
 
-export interface LedgerOptions {
-	transport: LedgerTransport;
-}
-
-// TODO: create a proper contract for this
 export type LedgerTransport = any;
+export type LedgerTransportFactory = () => Promise<LedgerTransport>;
 
 export type LedgerWalletList = Record<string, WalletData>;
 
 export interface LedgerService {
-	connect(transport: LedgerTransport): Promise<void>;
+	connect(): Promise<void>;
 
 	disconnect(): Promise<void>;
 

--- a/packages/sdk/source/services/ledger.service.ts
+++ b/packages/sdk/source/services/ledger.service.ts
@@ -6,14 +6,17 @@ import { WalletData } from "../contracts";
 import { NotImplemented } from "../exceptions";
 import { BindingType } from "../ioc/service-provider.contract";
 import { DataTransferObjectService } from "./data-transfer-object.contract";
-import { LedgerService, LedgerTransport, LedgerWalletList } from "./ledger.contract";
+import { LedgerService, LedgerTransportFactory, LedgerWalletList } from "./ledger.contract";
 
 @injectable()
 export class AbstractLedgerService implements LedgerService {
+	@inject(BindingType.LedgerTransportFactory)
+	protected readonly ledgerTransportFactory!: LedgerTransportFactory;
+
 	@inject(BindingType.DataTransferObjectService)
 	private readonly dataTransferObjectService!: DataTransferObjectService;
 
-	public async connect(transport: LedgerTransport): Promise<void> {
+	public async connect(): Promise<void> {
 		throw new NotImplemented(this.constructor.name, this.connect.name);
 	}
 

--- a/packages/trx/source/ledger.service.test.ts
+++ b/packages/trx/source/ledger.service.test.ts
@@ -23,9 +23,13 @@ const createMockService = async (record: string) => {
 			WalletData,
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
+		container.constant(
+			IoC.BindingType.LedgerTransportFactory,
+			async () => await openTransportReplayer(RecordStore.fromString(record)),
+		);
 	});
 
-	await transport.connect(await openTransportReplayer(RecordStore.fromString(record)));
+	await transport.connect();
 
 	return transport;
 };

--- a/packages/trx/source/ledger.service.ts
+++ b/packages/trx/source/ledger.service.ts
@@ -6,17 +6,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;
 	#transport!: Tron;
 
-	public override async connect(transport: Services.LedgerTransport): Promise<void> {
-		try {
-			this.#ledger = await transport.open();
-		} catch (error) {
-			if (transport.constructor.name === "TransportReplayer") {
-				this.#ledger = transport;
-			} else {
-				throw error;
-			}
-		}
-
+	public override async connect(): Promise<void> {
+		this.#ledger = await this.ledgerTransportFactory();
 		// @ts-ignore
 		this.#transport = new Tron.default(this.#ledger);
 	}

--- a/packages/xlm/source/ledger.service.test.ts
+++ b/packages/xlm/source/ledger.service.test.ts
@@ -23,9 +23,13 @@ const createMockService = async (record: string) => {
 			WalletData,
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
+		container.constant(
+			IoC.BindingType.LedgerTransportFactory,
+			async () => await openTransportReplayer(RecordStore.fromString(record)),
+		);
 	});
 
-	await transport.connect(await openTransportReplayer(RecordStore.fromString(record)));
+	await transport.connect();
 
 	return transport;
 };

--- a/packages/xlm/source/ledger.service.ts
+++ b/packages/xlm/source/ledger.service.ts
@@ -6,17 +6,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;
 	#transport!: Stellar;
 
-	public override async connect(transport: Services.LedgerTransport): Promise<void> {
-		try {
-			this.#ledger = await transport.open();
-		} catch (error) {
-			if (transport.constructor.name === "TransportReplayer") {
-				this.#ledger = transport;
-			} else {
-				throw error;
-			}
-		}
-
+	public override async connect(): Promise<void> {
+		this.#ledger = await this.ledgerTransportFactory();
 		// @ts-ignore
 		this.#transport = new Stellar.default(this.#ledger);
 	}

--- a/packages/xrp/source/ledger.service.test.ts
+++ b/packages/xrp/source/ledger.service.test.ts
@@ -23,9 +23,13 @@ const createMockService = async (record: string) => {
 			WalletData,
 		});
 		container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
+		container.constant(
+			IoC.BindingType.LedgerTransportFactory,
+			async () => await openTransportReplayer(RecordStore.fromString(record)),
+		);
 	});
 
-	await transport.connect(await openTransportReplayer(RecordStore.fromString(record)));
+	await transport.connect();
 
 	return transport;
 };

--- a/packages/xrp/source/ledger.service.ts
+++ b/packages/xrp/source/ledger.service.ts
@@ -6,17 +6,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;
 	#transport!: Ripple;
 
-	public override async connect(transport: Services.LedgerTransport): Promise<void> {
-		try {
-			this.#ledger = await transport.open();
-		} catch (error) {
-			if (transport.constructor.name === "TransportReplayer") {
-				this.#ledger = transport;
-			} else {
-				throw error;
-			}
-		}
-
+	public override async connect(): Promise<void> {
+		this.#ledger = await this.ledgerTransportFactory();
 		// @ts-ignore
 		this.#transport = new Ripple.default(this.#ledger);
 	}


### PR DESCRIPTION
> Resolves https://github.com/PayvoHQ/sdk/issues/340

Introduces a `LedgerTransportFactory` type which is a function. This function has to return the instance of the transport. During tests this will generally be `await openTransportReplayer` and in production `await import("@ledgerhq/hw-transport-node-hid-singleton").create().` or `await import("@ledgerhq/hw-transport-node-hid-singleton").open().` depending on the transport that is used by the client.