### PR TITLE
chore: use `tsc` for all build processes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,6 +38,6 @@ jobs:
             - name: Install dependencies
               run: node common/scripts/install-run-rush.js install
             - name: Build
-              run: node common/scripts/install-run-rush.js build --verbose
+              run: node common/scripts/install-run-rush.js build:npm --verbose
             - name: Publish
               run: NPM_AUTH_TOKEN=${{ secrets.NPM_AUTH_TOKEN }} node common/scripts/install-run-rush.js publish --publish --set-access-level=public --include-all

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -11,6 +11,30 @@
 		},
 		{
 			"commandKind": "bulk",
+			"name": "build:npm",
+			"summary": "...",
+			"description": "...",
+			"enableParallelism": true,
+			"allowWarningsInSuccessfulBuild": true
+		},
+		{
+			"commandKind": "bulk",
+			"name": "build:cjs",
+			"summary": "...",
+			"description": "...",
+			"enableParallelism": true,
+			"allowWarningsInSuccessfulBuild": true
+		},
+		{
+			"commandKind": "bulk",
+			"name": "build:esm",
+			"summary": "...",
+			"description": "...",
+			"enableParallelism": true,
+			"allowWarningsInSuccessfulBuild": true
+		},
+		{
+			"commandKind": "bulk",
 			"name": "format",
 			"summary": "...",
 			"description": "...",

--- a/packages/ada/package.json
+++ b/packages/ada/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -75,8 +76,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/ada/tsconfig.esm.json
+++ b/packages/ada/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/ada/tsconfig.json
+++ b/packages/ada/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/ark/package.json
+++ b/packages/ark/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -83,8 +84,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/ark/tsconfig.esm.json
+++ b/packages/ark/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/ark/tsconfig.json
+++ b/packages/ark/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -77,8 +78,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/atom/tsconfig.esm.json
+++ b/packages/atom/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/atom/tsconfig.json
+++ b/packages/atom/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/avax/package.json
+++ b/packages/avax/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -80,8 +81,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/avax/source/client.service.ts
+++ b/packages/avax/source/client.service.ts
@@ -4,7 +4,6 @@ import { AVMAPI, Tx } from "avalanche/dist/apis/avm";
 import { PlatformVMAPI } from "avalanche/dist/apis/platformvm";
 
 import { cb58Decode, usePChain, useXChain } from "./helpers";
-import { WalletIdentifier } from "@payvo/sdk/distribution/services";
 
 @IoC.injectable()
 export class ClientService extends Services.AbstractClientService {
@@ -34,7 +33,7 @@ export class ClientService extends Services.AbstractClientService {
 	public override async transactions(
 		query: Services.ClientTransactionsInput,
 	): Promise<Collections.ConfirmedTransactionDataCollection> {
-		const identifier: WalletIdentifier = query.identifiers![0];
+		const identifier: Services.WalletIdentifier = query.identifiers![0];
 
 		const { transactions } = await this.#get("v2/transactions", {
 			chainID: this.configRepository.get("network.meta.blockchainId"),

--- a/packages/avax/tsconfig.esm.json
+++ b/packages/avax/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/avax/tsconfig.json
+++ b/packages/avax/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/btc/package.json
+++ b/packages/btc/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -82,8 +83,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/btc/source/client.service.test.ts
+++ b/packages/btc/source/client.service.test.ts
@@ -9,7 +9,7 @@ import { SignedTransactionData } from "./signed-transaction.dto";
 import { WalletData } from "./wallet.dto";
 import { ClientService } from "./client.service";
 import { ConfirmedTransactionData } from "./confirmed-transaction.dto";
-import { ConfirmedTransactionDataCollection } from "@payvo/sdk/distribution/collections";
+import { ConfirmedTransactionDataCollection } from "@payvo/sdk/distribution/cjs/collections";
 
 let subject: ClientService;
 

--- a/packages/btc/tsconfig.esm.json
+++ b/packages/btc/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/btc/tsconfig.json
+++ b/packages/btc/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -87,8 +88,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4",
 		"wif": "^2.0.6"

--- a/packages/cryptography/tsconfig.esm.json
+++ b/packages/cryptography/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/cryptography/tsconfig.json
+++ b/packages/cryptography/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/dot/package.json
+++ b/packages/dot/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -83,8 +84,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/dot/tsconfig.esm.json
+++ b/packages/dot/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/dot/tsconfig.json
+++ b/packages/dot/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/egld/package.json
+++ b/packages/egld/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -76,8 +77,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/egld/tsconfig.esm.json
+++ b/packages/egld/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/egld/tsconfig.json
+++ b/packages/egld/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/eos/package.json
+++ b/packages/eos/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -76,8 +77,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/eos/tsconfig.esm.json
+++ b/packages/eos/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/eos/tsconfig.json
+++ b/packages/eos/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/eth/package.json
+++ b/packages/eth/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -79,8 +80,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/eth/tsconfig.esm.json
+++ b/packages/eth/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/eth/tsconfig.json
+++ b/packages/eth/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -86,8 +87,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/helpers/tsconfig.esm.json
+++ b/packages/helpers/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/helpers/tsconfig.json
+++ b/packages/helpers/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/http-fetch/package.json
+++ b/packages/http-fetch/package.json
@@ -4,19 +4,20 @@
 	"description": "HTTP Client for @payvo/sdk",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -69,8 +70,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/http-fetch/tsconfig.esm.json
+++ b/packages/http-fetch/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/http-fetch/tsconfig.json
+++ b/packages/http-fetch/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -67,8 +68,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/intl/tsconfig.esm.json
+++ b/packages/intl/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/intl/tsconfig.json
+++ b/packages/intl/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/lsk/package.json
+++ b/packages/lsk/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -76,8 +77,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/lsk/tsconfig.esm.json
+++ b/packages/lsk/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/lsk/tsconfig.json
+++ b/packages/lsk/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/luna/package.json
+++ b/packages/luna/package.json
@@ -12,11 +12,10 @@
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -74,8 +73,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/luna/tsconfig.esm.json
+++ b/packages/luna/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/luna/tsconfig.json
+++ b/packages/luna/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/markets/package.json
+++ b/packages/markets/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -69,8 +70,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/markets/tsconfig.esm.json
+++ b/packages/markets/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/markets/tsconfig.json
+++ b/packages/markets/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/nano/package.json
+++ b/packages/nano/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -76,8 +77,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/nano/tsconfig.esm.json
+++ b/packages/nano/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/nano/tsconfig.json
+++ b/packages/nano/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/neo/package.json
+++ b/packages/neo/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -66,8 +67,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/neo/tsconfig.esm.json
+++ b/packages/neo/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/neo/tsconfig.json
+++ b/packages/neo/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/news/package.json
+++ b/packages/news/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -69,8 +70,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/news/tsconfig.esm.json
+++ b/packages/news/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/news/tsconfig.json
+++ b/packages/news/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -4,19 +4,20 @@
 	"description": "Profiles for @payvo/sdk",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -100,8 +101,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4",
 		"wif": "^2.0.6"

--- a/packages/profiles/test/integration/btc-wallets.test.ts
+++ b/packages/profiles/test/integration/btc-wallets.test.ts
@@ -2,7 +2,7 @@ import "jest-extended";
 import "reflect-metadata";
 
 import { BIP44 } from "@payvo/sdk-cryptography";
-import { AddressDataTransferObject } from "@payvo/sdk/distribution/services/address.contract";
+import { AddressDataTransferObject } from "@payvo/sdk/distribution/cjs/services/address.contract";
 import nock from "nock";
 
 import { Profile } from "../../source";

--- a/packages/profiles/tsconfig.esm.json
+++ b/packages/profiles/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/profiles/tsconfig.json
+++ b/packages/profiles/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -82,8 +83,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/sdk/source/coins/coin-factory.test.ts
+++ b/packages/sdk/source/coins/coin-factory.test.ts
@@ -5,7 +5,7 @@ import "reflect-metadata";
 
 import nock from "nock";
 
-import { ARK } from "../../../ark/distribution";
+import { ARK } from "../../../ark/distribution/cjs";
 import { Request } from "../../../http-fetch";
 import { requireModule } from "../../test/mocking";
 import { Coin } from "./coin";

--- a/packages/sdk/source/coins/coin.test.ts
+++ b/packages/sdk/source/coins/coin.test.ts
@@ -3,7 +3,7 @@ import "reflect-metadata";
 
 import nock from "nock";
 
-import { ARK } from "../../../ark/distribution";
+import { ARK } from "../../../ark/distribution/cjs";
 import { Request } from "../../../http-fetch";
 import { requireModule } from "../../test/mocking";
 import { Network, NetworkRepository } from "../networks";

--- a/packages/sdk/source/networks/network-repository.test.ts
+++ b/packages/sdk/source/networks/network-repository.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
 
-import { manifest } from "../../../ark/distribution/manifest";
+import { manifest } from "../../../ark/distribution/cjs/manifest";
 import { NetworkRepository } from "./network-repository";
 
 let subject: NetworkRepository;

--- a/packages/sdk/source/networks/network.test.ts
+++ b/packages/sdk/source/networks/network.test.ts
@@ -2,7 +2,7 @@ import "jest-extended";
 
 import { jest } from "@jest/globals";
 
-import { manifest } from "../../../ark/distribution/manifest";
+import { manifest } from "../../../ark/distribution/cjs/manifest";
 import { FeatureFlag } from "../enums";
 import { Network } from "./network";
 

--- a/packages/sdk/tsconfig.esm.json
+++ b/packages/sdk/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/sol/package.json
+++ b/packages/sol/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -76,8 +77,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/sol/tsconfig.esm.json
+++ b/packages/sol/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/sol/tsconfig.json
+++ b/packages/sol/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/trx/package.json
+++ b/packages/trx/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -75,8 +76,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/trx/tsconfig.esm.json
+++ b/packages/trx/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/trx/tsconfig.json
+++ b/packages/trx/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/xlm/package.json
+++ b/packages/xlm/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -75,8 +76,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/xlm/tsconfig.esm.json
+++ b/packages/xlm/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/xlm/tsconfig.json
+++ b/packages/xlm/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/xrp/package.json
+++ b/packages/xrp/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -80,8 +81,6 @@
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
 		"ripple-binary-codec": "^1.1.3",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/xrp/tsconfig.esm.json
+++ b/packages/xrp/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/xrp/tsconfig.json
+++ b/packages/xrp/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/packages/zil/package.json
+++ b/packages/zil/package.json
@@ -4,19 +4,20 @@
 	"description": "Cross-Platform Utilities for ARK Applications",
 	"license": "MIT",
 	"contributors": [],
-	"main": "distribution/index.js",
-	"unpkg": "distribution/index.umd.min.js",
-	"module": "distribution/index.min.mjs",
-	"types": "distribution/index.d.ts",
+	"exports": {
+		"import": "./src/esm/index.js",
+		"require": "./src/cjs/index.js"
+	},
+	"main": "distribution/cjs/index.js",
+	"types": "distribution/cjs/index.d.ts",
 	"files": [
 		"/distribution"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc",
-		"bundle:esm": "rollup distribution/index.js --file distribution/index.mjs --format esm",
-		"bundle:esm:min": "terser --ecma 2019 --compress --mangle --module -o distribution/index.min.mjs -- distribution/index.mjs && gzip -9 -c distribution/index.min.mjs > distribution/index.min.mjs.gz",
-		"bundle:umd": "rollup distribution/index.js --file distribution/index.umd.js --format umd",
-		"bundle:umd:min": "terser --ecma 2019 --compress --mangle -o distribution/index.umd.min.js -- distribution/index.umd.js && gzip -9 -c distribution/index.umd.min.js > distribution/index.umd.min.js.gz",
+		"build": "pnpm run build:cjs",
+		"build:cjs": "tsc -p tsconfig.json",
+		"build:esm": "tsc -p tsconfig.esm.json",
+		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
 		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
@@ -76,8 +77,6 @@
 		"npm-check-updates": "^12.0.2",
 		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.59.0",
-		"terser": "^5.9.0",
 		"ts-jest": "^27.0.7",
 		"typescript": "^4.4.4"
 	},

--- a/packages/zil/tsconfig.esm.json
+++ b/packages/zil/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.esm.json",
+	"compilerOptions": {
+		"outDir": "distribution/esm",
+		"typeRoots": ["./node_modules/@types"]
+	},
+	"include": ["source/**/**.ts"]
+}

--- a/packages/zil/tsconfig.json
+++ b/packages/zil/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "distribution",
+		"outDir": "distribution/cjs",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"include": ["source/**/**.ts"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,42 @@
+{
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "declaration": true,
+        "emitDecoratorMetadata": true,
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "forceConsistentCasingInFileNames": true,
+        "incremental": true,
+        "moduleResolution": "node",
+        "newLine": "lf",
+        "noEmitOnError": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": false,
+        "noImplicitOverride": true,
+        "noImplicitReturns": true,
+        "noPropertyAccessFromIndexSignature": false,
+        "noUncheckedIndexedAccess": false,
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "outDir": "distribution",
+        "pretty": true,
+        "resolveJsonModule": true,
+        "skipLibCheck": true,
+        "sourceMap": true,
+        "strict": true,
+        "stripInternal": true,
+        "typeRoots": [
+            "./node_modules/@types"
+        ],
+        "useDefineForClassFields": true,
+        "useUnknownInCatchVariables": false
+    },
+    "exclude": [
+        "distribution",
+        "**/*.spec.ts",
+        "**/*.test.ts"
+    ],
+    "files": [
+        "types/global.d.ts"
+    ]
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"lib": [
+			"esnext",
+			"dom"
+		],
+		"module": "esnext",
+		"target": "esnext",
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,36 +1,11 @@
 {
+	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
-		"allowSyntheticDefaultImports": true,
-		"declaration": true,
-		"emitDecoratorMetadata": true,
-		"esModuleInterop": true,
-		"experimentalDecorators": true,
-		"forceConsistentCasingInFileNames": true,
-		"lib": ["es2019", "dom"],
+		"lib": [
+			"es2019",
+			"dom"
+		],
 		"module": "commonjs",
-		"moduleResolution": "node",
-		"newLine": "lf",
-		"noEmitOnError": true,
-		"noFallthroughCasesInSwitch": true,
-		"noImplicitAny": false,
-		"noImplicitOverride": true,
-		"noImplicitReturns": true,
-		"noPropertyAccessFromIndexSignature": false,
-		"noUncheckedIndexedAccess": false,
-		"noUnusedLocals": false,
-		"noUnusedParameters": false,
-		"outDir": "distribution",
-		"pretty": true,
-		"resolveJsonModule": true,
-		"skipLibCheck": true,
-		"sourceMap": true,
-		"strict": true,
-		"stripInternal": true,
-		"target": "es2019",
-		"typeRoots": ["./node_modules/@types"],
-		"useDefineForClassFields": true,
-		"useUnknownInCatchVariables": false
-	},
-	"exclude": ["distribution", "**/*.spec.ts", "**/*.test.ts"],
-	"files": ["types/global.d.ts"]
+		"target": "es2019"
+	}
 }


### PR DESCRIPTION
Updates the build process to only rely on `tsc`. This means we only rely on the typescript compiler and different configurations for it rather than more tooling.