### PR TITLE
chore: move `prettier` to root of repository

### DIFF
--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -45,7 +45,7 @@ jobs:
             - name: Lint
               run: rush lint || true
             - name: Format
-              run: rush prettier
+              run: pnpm run prettier
             - uses: stefanzweifel/git-auto-commit-action@v4
               with:
                   commit_message: "style: resolve style guide violations"

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -35,13 +35,6 @@
 		},
 		{
 			"commandKind": "bulk",
-			"name": "format",
-			"summary": "...",
-			"description": "...",
-			"enableParallelism": true
-		},
-		{
-			"commandKind": "bulk",
 			"name": "lint",
 			"summary": "...",
 			"description": "...",
@@ -50,13 +43,6 @@
 		{
 			"commandKind": "bulk",
 			"name": "lint:tests",
-			"summary": "...",
-			"description": "...",
-			"enableParallelism": true
-		},
-		{
-			"commandKind": "bulk",
-			"name": "prettier",
 			"summary": "...",
 			"description": "...",
 			"enableParallelism": true

--- a/package.json
+++ b/package.json
@@ -2,11 +2,15 @@
 	"name": "platform-sdk",
 	"private": true,
 	"description": "Cross-Platform Utilities for ARK Applications",
+	"scripts": {
+		"prettier": "prettier --write \"./packages/**/*.{ts,js,json,md}\""
+	},
 	"dependencies": {
+		"prettier": "^2.4.1",
 		"ts-morph": "^12.0.0"
 	},
 	"engines": {
-		"node": "^12 || ^14"
+		"node": ">=14.16"
 	},
 	"engineStrict": true
 }

--- a/packages/ada/package.json
+++ b/packages/ada/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-ada",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -80,6 +78,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/ark/package.json
+++ b/packages/ark/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-ark",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -88,6 +86,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-atom",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -82,6 +80,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/avax/package.json
+++ b/packages/avax/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-avax",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -85,6 +83,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/btc/package.json
+++ b/packages/btc/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-btc",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --detectOpenHandles",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -87,6 +85,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-cryptography",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -93,6 +91,6 @@
 		"wif": "^2.0.6"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/dot/package.json
+++ b/packages/dot/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-dot",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -88,6 +86,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/egld/package.json
+++ b/packages/egld/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-egld",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -81,6 +79,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/eos/package.json
+++ b/packages/eos/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-eos",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -81,6 +79,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/eth/package.json
+++ b/packages/eth/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-eth",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -84,6 +82,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-helpers",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -91,6 +89,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/http-fetch/package.json
+++ b/packages/http-fetch/package.json
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -74,6 +72,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-intl",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --detectOpenHandles",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -72,6 +70,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/lsk/package.json
+++ b/packages/lsk/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-lsk",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -81,6 +79,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/luna/package.json
+++ b/packages/luna/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-luna",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"main": "distribution/index.js",
@@ -17,11 +17,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -77,6 +75,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/markets/package.json
+++ b/packages/markets/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-markets",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --detectOpenHandles",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -74,6 +72,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/nano/package.json
+++ b/packages/nano/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-nano",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -81,6 +79,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/neo/package.json
+++ b/packages/neo/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-neo",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -71,6 +69,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/news/package.json
+++ b/packages/news/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-news",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --detectOpenHandles",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -74,6 +72,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -106,6 +104,6 @@
 		"wif": "^2.0.6"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -87,6 +85,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/sol/package.json
+++ b/packages/sol/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-sol",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -81,6 +79,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/trx/package.json
+++ b/packages/trx/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-trx",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -80,6 +78,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/xlm/package.json
+++ b/packages/xlm/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-xlm",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -80,6 +78,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/xrp/package.json
+++ b/packages/xrp/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-xrp",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -85,6 +83,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/packages/zil/package.json
+++ b/packages/zil/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@payvo/sdk-zil",
 	"version": "3.2.0",
-	"description": "Cross-Platform Utilities for ARK Applications",
+	"description": "Cross-Platform Utilities for Payvo Applications",
 	"license": "MIT",
 	"contributors": [],
 	"exports": {
@@ -19,11 +19,9 @@
 		"build:esm": "tsc -p tsconfig.esm.json",
 		"build:npm": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm",
 		"clean": "rimraf .coverage distribution tmp",
-		"format": "pnpm run lint && pnpm run prettier",
 		"lint": "eslint source/**/*.ts --fix",
 		"lint:tests": "eslint source/**/*.test.ts --fix",
 		"prepublishOnly": "pnpm run build:npm",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
 		"test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --watchAll"
 	},
@@ -81,6 +79,6 @@
 		"typescript": "^4.4.4"
 	},
 	"engines": {
-		"node": ">=12.x"
+		"node": ">=14.16"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,11 @@
 lockfileVersion: 5.3
 
 specifiers:
+  prettier: ^2.4.1
   ts-morph: ^12.0.0
 
 dependencies:
+  prettier: 2.4.1
   ts-morph: 12.0.0
 
 packages:
@@ -144,6 +146,12 @@ packages:
   /picomatch/2.3.0:
     resolution: {integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==}
     engines: {node: '>=8.6'}
+    dev: false
+
+  /prettier/2.4.1:
+    resolution: {integrity: sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
     dev: false
 
   /queue-microtask/1.2.3:


### PR DESCRIPTION
Instead of running prettier for each directly we just run it for `packages/**` from the root. This is faster than `rush prettier` and achieves the same. Also raises the minimum node version to ensure some dependencies work as intended.