### PR TITLE
feat(test): implement `describe` for suites

### DIFF
--- a/packages/test/source/describe.test.js
+++ b/packages/test/source/describe.test.js
@@ -1,0 +1,29 @@
+import { describe } from "./describe";
+
+describe("Date.now()", ({ assert, before, after, only, skip, test }) => {
+	let _Date;
+
+	before(() => {
+		let count = 0;
+		_Date = global.Date;
+		global.Date = { now: () => 100 + count++ };
+	});
+
+	after(() => {
+		global.Date = _Date;
+	});
+
+	skip("should be a function", () => {
+		assert.type(Date.now, "function");
+	});
+
+	test("should return a number", () => {
+		assert.type(Date.now(), "number");
+	});
+
+	only("should progress with time", () => {
+		assert.is(Date.now(), 100);
+		assert.is(Date.now(), 101);
+		assert.is(Date.now(), 102);
+	});
+});

--- a/packages/test/source/describe.ts
+++ b/packages/test/source/describe.ts
@@ -1,9 +1,21 @@
 import { suite } from "uvu";
 
-export const describe = (title: string, tests: Function): void => {
+import { assert } from "./assert.js";
+
+export const describe = (title: string, callback: Function): void => {
 	const instance = suite(title);
 
-	tests(instance);
+	callback({
+		after: instance.after,
+		afterEach: instance.after.each,
+		assert,
+		before: instance.before,
+		beforeEach: instance.before.each,
+		it: instance,
+		only: instance.only,
+		skip: instance.skip,
+		test: instance,
+	});
 
 	instance.run();
 };


### PR DESCRIPTION
> Resolves https://github.com/PayvoHQ/sdk/issues/419

This implements the exact syntax describe in the linked issue. This mostly mirrors jest but the big difference is that you need to destruct the callback to get access to all the hooks like before, after, only, skip, test and so on.

This is done this way to ensure that you are always creating everything in the local scope. Local scope in this context means everything inside the `describe` block. This ensures that no state is leaked between multiple suites in a single file.

It also exposes `assert` through the callback, which can also be imported from `@payvo/sdk-test` directly. This is done for consistency to make it clear where everything that is used is coming from. It also exports an `it` function which is an alias of `test`. The `test` method will eventually be removed once all tests use the `it` function.

**This PR only adds the helper. The migration of `describe` blocks will be done in another PR.**