### PR TITLE
test: use new `describe` syntax

### DIFF
--- a/packages/ada/source/client.service.test.js
+++ b/packages/ada/source/client.service.test.js
@@ -54,43 +54,41 @@ test("#wallet should succeed", async () => {
 	assert.object(result.balance());
 });
 
-describe("#transactions", () => {
-	test("returns ok", async () => {
-		nock(/.+/)
-			.post("/")
-			.reply(200, loader.json(`test/fixtures/client/transactions-0.json`))
-			.post("/")
-			.reply(200, loader.json(`test/fixtures/client/transactions-20.json`))
-			.post("/")
-			.reply(200, loader.json(`test/fixtures/client/transactions.json`));
+test("#transactions should ", async () => {
+	nock(/.+/)
+		.post("/")
+		.reply(200, loader.json(`test/fixtures/client/transactions-0.json`))
+		.post("/")
+		.reply(200, loader.json(`test/fixtures/client/transactions-20.json`))
+		.post("/")
+		.reply(200, loader.json(`test/fixtures/client/transactions.json`));
 
-		const result = await subject.transactions({
-			senderPublicKey:
-				"aec30330deaecdd7503195a0d730256faef87027022b1bdda7ca0a61bca0a55e4d575af5a93bdf4905a3702fadedf451ea584791d233ade90965d608bac57304",
-		});
-		assert.length(result.items(), 5);
-		assert.instance(result.items()[0], ConfirmedTransactionData);
+	const result = await subject.transactions({
+		senderPublicKey:
+			"aec30330deaecdd7503195a0d730256faef87027022b1bdda7ca0a61bca0a55e4d575af5a93bdf4905a3702fadedf451ea584791d233ade90965d608bac57304",
 	});
-	test("missing senderPublicKey", async () => {
-		await assert.rejects(
-			() =>
-				subject.transactions({
-					identifiers: [
-						{
-							type: "extendedPublicKey",
-							value: "aec30330deaecdd7503195a0d730256faef87027022b1bdda7ca0a61bca0a55e4d575af5a93bdf4905a3702fadedf451ea584791d233ade90965d608bac57304",
-						},
-					],
-				}),
-			"Method ClientService#transactions expects the argument [senderPublicKey] but it was not given",
-		);
-	});
-	test("missing query", async () => {
-		await assert.rejects(
-			() => subject.transactions({}),
-			"Method ClientService#transactions expects the argument [senderPublicKey] but it was not given",
-		);
-	});
+	assert.length(result.items(), 5);
+	assert.instance(result.items()[0], ConfirmedTransactionData);
+});
+
+test("#transactions should fail if the sender public key is missing", async () => {
+	await assert.rejects(
+		() =>
+			subject.transactions({
+				identifiers: [
+					{
+						type: "extendedPublicKey",
+						value: "aec30330deaecdd7503195a0d730256faef87027022b1bdda7ca0a61bca0a55e4d575af5a93bdf4905a3702fadedf451ea584791d233ade90965d608bac57304",
+					},
+				],
+			}),
+		"Method ClientService#transactions expects the argument [senderPublicKey] but it was not given",
+	);
+
+	await assert.rejects(
+		() => subject.transactions({}),
+		"Method ClientService#transactions expects the argument [senderPublicKey] but it was not given",
+	);
 });
 
 test("#transaction", async () => {

--- a/packages/ark/source/client.service.test.js
+++ b/packages/ark/source/client.service.test.js
@@ -36,8 +36,8 @@ test("#transaction", async () => {
 	assert.instance(result, ConfirmedTransactionData);
 });
 
-describe("transactions should work with Core 2.0", (suite) => {
-	suite.before.each(async () => {
+describe("transactions should work with Core 2.0", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ClientService, "ark.mainnet", (container) => {
 			container.constant(IoC.BindingType.Container, container);
 			container.constant(IoC.BindingType.DataTransferObjects, {
@@ -49,7 +49,7 @@ describe("transactions should work with Core 2.0", (suite) => {
 		});
 	});
 
-	suite("single address", async () => {
+	test("single address", async () => {
 		nock(/.+/)
 			.get("/api/transactions")
 			.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8", page: "0" })
@@ -64,7 +64,7 @@ describe("transactions should work with Core 2.0", (suite) => {
 		assert.instance(result.items()[0], ConfirmedTransactionData);
 	});
 
-	suite("multiple addresses", async () => {
+	test("multiple addresses", async () => {
 		nock(/.+/)
 			.get("/api/transactions")
 			.query({
@@ -86,8 +86,8 @@ describe("transactions should work with Core 2.0", (suite) => {
 	});
 });
 
-describe("should work with Core 3.0", (suite) => {
-	suite.before.each(async () => {
+describe("should work with Core 3.0", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ClientService, "ark.devnet", (container) => {
 			container.constant(IoC.BindingType.Container, container);
 			container.constant(IoC.BindingType.DataTransferObjects, {
@@ -99,7 +99,7 @@ describe("should work with Core 3.0", (suite) => {
 		});
 	});
 
-	suite("single address", async () => {
+	test("single address", async () => {
 		nock(/.+/)
 			.get("/api/transactions")
 			.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8" })
@@ -113,7 +113,7 @@ describe("should work with Core 3.0", (suite) => {
 		assert.instance(result.items()[0], ConfirmedTransactionData);
 	});
 
-	suite("multiple addresses", async () => {
+	test("multiple addresses", async () => {
 		nock(/.+/)
 			.get("/api/transactions")
 			.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8,DRwgqrfuuaPCy3AE8Sz1AjdrncKfHjePn5" })
@@ -130,7 +130,7 @@ describe("should work with Core 3.0", (suite) => {
 		assert.instance(result.items()[0], ConfirmedTransactionData);
 	});
 
-	suite("for advanced search", async () => {
+	test("for advanced search", async () => {
 		nock(/.+/)
 			.get("/api/transactions")
 			.query({
@@ -166,8 +166,8 @@ test("#wallet", async () => {
 	assert.instance(result, WalletData);
 });
 
-describe("#wallets", (suite) => {
-	suite("should work with Core 2.0", async () => {
+describe("#wallets", ({ afterEach, beforeEach, test }) => {
+	test("should work with Core 2.0", async () => {
 		subject = await createService(ClientService, "ark.mainnet", (container) => {
 			container.constant(IoC.BindingType.Container, container);
 			container.constant(IoC.BindingType.DataTransferObjects, {
@@ -191,7 +191,7 @@ describe("#wallets", (suite) => {
 		assert.instance(result.items()[0], WalletData);
 	});
 
-	suite("should work with Core 3.0", async () => {
+	test("should work with Core 3.0", async () => {
 		subject = await createService(ClientService, "ark.devnet", (container) => {
 			container.constant(IoC.BindingType.Container, container);
 			container.constant(IoC.BindingType.DataTransferObjects, {
@@ -233,7 +233,7 @@ test("#delegates", async () => {
 	assert.instance(result.items()[0], WalletData);
 });
 
-describe("#votes", (suite) => {
+describe("#votes", ({ afterEach, beforeEach, test }) => {
 	let fixture;
 
 	test.before.each(async () => {
@@ -320,14 +320,14 @@ test("#voters", async () => {
 	assert.instance(result.items()[0], WalletData);
 });
 
-describe("#broadcast", (suite) => {
+describe("#broadcast", ({ afterEach, beforeEach, test }) => {
 	let fixture;
 
-	suite.before.each(async () => {
+	beforeEach(async () => {
 		fixture = loader.json(`test/fixtures/client/broadcast.json`);
 	});
 
-	suite("should accept 1 transaction and reject 1 transaction", async () => {
+	test("should accept 1 transaction and reject 1 transaction", async () => {
 		nock(/.+/).post("/api/transactions").reply(422, fixture);
 
 		const mock = { toBroadcast: () => "" };
@@ -342,7 +342,7 @@ describe("#broadcast", (suite) => {
 		});
 	});
 
-	suite("should read errors in non-array format", async () => {
+	test("should read errors in non-array format", async () => {
 		const errorId = Object.keys(fixture.errors)[0];
 		const nonArrayFixture = {
 			data: fixture.data,

--- a/packages/ark/source/confirmed-transaction.dto.test.js
+++ b/packages/ark/source/confirmed-transaction.dto.test.js
@@ -79,7 +79,12 @@ test("#isConfirmed", () => {
 	assert.true(subject.isConfirmed());
 });
 
-describe("#isReturn", (suite) => {
+describe("#isReturn", ({ beforeEach, test }) => {
+	beforeEach(async () => {
+		subject = await createService(ConfirmedTransactionData);
+		subject.configure(Fixture.data);
+	});
+
 	test("should return true for transfers if sender equals recipient", () => {
 		mockery(subject, "isTransfer").mockReturnValueOnce(true);
 		mockery(subject, "isSent").mockReturnValueOnce(true);
@@ -202,54 +207,54 @@ test("#type", () => {
 	assert.is(subject.type(), "transfer");
 });
 
-describe("DelegateRegistrationData", (suite) => {
-	suite.before.each(async () => {
+describe("DelegateRegistrationData", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ConfirmedTransactionData);
 		subject.configure(CryptoConfiguration.data.genesisBlock.transactions[1]);
 	});
 
-	suite("#id", () => {
+	test("#id", () => {
 		assert.is(subject.username(), "genesis_1");
 	});
 
-	suite("#type", () => {
+	test("#type", () => {
 		assert.is(subject.type(), "delegateRegistration");
 	});
 });
 
-describe("DelegateResignationData", (suite) => {
-	suite.before.each(async () => {
+describe("DelegateResignationData", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		CryptoConfiguration.data.genesisBlock.transactions[1].type = 7;
 		subject = await createService(ConfirmedTransactionData);
 		subject.configure(CryptoConfiguration.data.genesisBlock.transactions[1]);
 	});
 
-	suite("#type", () => {
+	test("#type", () => {
 		assert.is(subject.type(), "delegateResignation");
 	});
 });
 
-describe("HtlcClaimData", (suite) => {
-	suite.before.each(async () => {
+describe("HtlcClaimData", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ConfirmedTransactionData);
 		subject.configure({ type: 9, asset: { lock: { lockTransactionId: "1", unlockSecret: "2" } } });
 	});
 
-	suite("#lockTransactionId", () => {
+	test("#lockTransactionId", () => {
 		assert.is(subject.lockTransactionId(), "1");
 	});
 
-	suite("#unlockSecret", () => {
+	test("#unlockSecret", () => {
 		assert.is(subject.unlockSecret(), "2");
 	});
 
-	suite("#type", () => {
+	test("#type", () => {
 		assert.is(subject.type(), "htlcClaim");
 	});
 });
 
-describe("HtlcLockData", (suite) => {
-	suite.before.each(async () => {
+describe("HtlcLockData", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ConfirmedTransactionData);
 		subject.configure({
 			type: 8,
@@ -267,55 +272,55 @@ describe("HtlcLockData", (suite) => {
 		});
 	});
 
-	suite("#secretHash", () => {
+	test("#secretHash", () => {
 		assert.is(subject.secretHash(), "0f128d401958b1b30ad0d10406f47f9489321017b4614e6cb993fc63913c5454");
 	});
 
-	suite("#expirationType", () => {
+	test("#expirationType", () => {
 		assert.is(subject.expirationType(), 1);
 	});
 
-	suite("#expirationValue", () => {
+	test("#expirationValue", () => {
 		assert.is(subject.expirationValue(), 123456789);
 	});
 
-	suite("#type", () => {
+	test("#type", () => {
 		assert.is(subject.type(), "htlcLock");
 	});
 });
 
-describe("HtlcRefundData", (suite) => {
-	suite.before.each(async () => {
+describe("HtlcRefundData", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ConfirmedTransactionData);
 		subject.configure({ type: 10, asset: { refund: { lockTransactionId: "1", unlockSecret: "2" } } });
 	});
 
-	suite("#lockTransactionId", () => {
+	test("#lockTransactionId", () => {
 		assert.is(subject.lockTransactionId(), "1");
 	});
 
-	suite("#type", () => {
+	test("#type", () => {
 		assert.is(subject.type(), "htlcRefund");
 	});
 });
 
-describe("IpfsData", (suite) => {
-	suite.before.each(async () => {
+describe("IpfsData", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ConfirmedTransactionData);
 		subject.configure({ type: 5, asset: { ipfs: "123456789" } });
 	});
 
-	suite("#lockTransactionId", () => {
+	test("#lockTransactionId", () => {
 		assert.is(subject.hash(), "123456789");
 	});
 
-	suite("#type", () => {
+	test("#type", () => {
 		assert.is(subject.type(), "ipfs");
 	});
 });
 
-describe("MultiPaymentData", (suite) => {
-	suite.before.each(async () => {
+describe("MultiPaymentData", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ConfirmedTransactionData);
 		subject.configure({
 			type: 6,
@@ -329,21 +334,21 @@ describe("MultiPaymentData", (suite) => {
 		});
 	});
 
-	suite("#memo", () => {
+	test("#memo", () => {
 		assert.undefined(subject.memo());
 	});
 
-	suite("#payments", () => {
+	test("#payments", () => {
 		assert.length(subject.payments(), 3);
 	});
 
-	suite("#type", () => {
+	test("#type", () => {
 		assert.is(subject.type(), "multiPayment");
 	});
 });
 
-describe("MultiSignatureData", (suite) => {
-	suite.before.each(async () => {
+describe("MultiSignatureData", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ConfirmedTransactionData);
 		subject.configure({
 			type: 4,
@@ -356,66 +361,66 @@ describe("MultiSignatureData", (suite) => {
 		});
 	});
 
-	suite("#publicKeys", () => {
+	test("#publicKeys", () => {
 		assert.length(subject.publicKeys(), 2);
 	});
 
-	suite("#min", () => {
+	test("#min", () => {
 		assert.is(subject.min(), 1);
 	});
 
-	suite("#type", () => {
+	test("#type", () => {
 		assert.is(subject.type(), "multiSignature");
 	});
 });
 
-describe("SecondSignatureData", (suite) => {
-	suite.before.each(async () => {
+describe("SecondSignatureData", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ConfirmedTransactionData);
 		subject.configure({ type: 1, asset: { signature: { publicKey: "1" } } });
 	});
 
-	suite("#publicKeys", () => {
+	test("#publicKeys", () => {
 		assert.is(subject.secondPublicKey(), "1");
 	});
 
-	suite("#type", () => {
+	test("#type", () => {
 		assert.is(subject.type(), "secondSignature");
 	});
 });
 
-describe("TransferData", (suite) => {
-	suite.before.each(async () => {
+describe("TransferData", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ConfirmedTransactionData);
 		subject.configure({ vendorField: "X" });
 	});
 
-	suite("#memo", () => {
+	test("#memo", () => {
 		assert.is(subject.memo(), "X");
 	});
 
-	suite("#type", () => {
+	test("#type", () => {
 		assert.is(subject.type(), "transfer");
 	});
 });
 
-describe("VoteData", (suite) => {
-	suite.before.each(async () => {
+describe("VoteData", ({ beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(ConfirmedTransactionData);
 		subject.configure({ type: 3, asset: { votes: ["+A", "-B"] } });
 	});
 
-	suite("#votes", () => {
+	test("#votes", () => {
 		assert.length(subject.votes(), 1);
 		assert.is(subject.votes()[0], "A");
 	});
 
-	suite("#unvotes", () => {
+	test("#unvotes", () => {
 		assert.length(subject.unvotes(), 1);
 		assert.is(subject.unvotes()[0], "B");
 	});
 
-	suite("#type", () => {
+	test("#type", () => {
 		subject.configure({ type: 3, asset: { votes: ["+A", "-B"] } });
 
 		assert.is(subject.type(), "voteCombination");

--- a/packages/ark/source/ledger.service.test.js
+++ b/packages/ark/source/ledger.service.test.js
@@ -78,12 +78,12 @@ test("should pass with a schnorr signature", async () => {
 	);
 });
 
-describe("scan", (suite) => {
-	suite.before(() => nock.disableNetConnect());
+describe("scan", ({ afterEach, beforeAll, test }) => {
+	beforeAll(() => nock.disableNetConnect());
 
-	suite.after.each(() => nock.cleanAll());
+	afterEach(() => nock.cleanAll());
 
-	suite("should scan for legacy wallets", async () => {
+	test("should scan for legacy wallets", async () => {
 		nock(/.+/)
 			.get(
 				"/api/wallets?address=D9xJncW4ECUSJQWeLP7wncxhDTvNeg2HNK%2CDFgggtreMXQNQKnxHddvkaPHcQbRdK3jyJ%2CDFr1CR81idSmfgQ19KXe4M6keqUEAuU8kF%2CDTYiNbvTKveMtJC8KPPdBrgRWxfPxGp1WV%2CDJyGFrZv4MYKrTMcjzEyhZzdTAJju2Rcjr",
@@ -111,7 +111,7 @@ describe("scan", (suite) => {
 		}
 	});
 
-	suite("should scan for new wallets", async () => {
+	test("should scan for new wallets", async () => {
 		nock(/.+/)
 			.get("/api/wallets")
 			.query(true)

--- a/packages/ark/source/link.service.test.js
+++ b/packages/ark/source/link.service.test.js
@@ -5,128 +5,128 @@ import { createService } from "../test/mocking";
 
 let subject;
 
-describe("ark.mainnet", (suite) => {
-	suite.before(async () => {
+describe("ark.mainnet", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(Services.AbstractLinkService, "ark.mainnet");
 	});
 
-	suite("should generate a link for a block", async () => {
+	test("should generate a link for a block", async () => {
 		assert.is(subject.block("id"), "https://explorer.ark.io/block/id");
 	});
 
-	suite("should generate a link for a transaction", async () => {
+	test("should generate a link for a transaction", async () => {
 		assert.is(subject.transaction("id"), "https://explorer.ark.io/transaction/id");
 	});
 
-	suite("should generate a link for a wallet", async () => {
+	test("should generate a link for a wallet", async () => {
 		assert.is(subject.wallet("id"), "https://explorer.ark.io/wallets/id");
 	});
 });
 
-describe("ark.devnet", (suite) => {
-	suite.before(async () => {
+describe("ark.devnet", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(Services.AbstractLinkService, "ark.devnet");
 	});
 
-	suite("should generate a link for a block", async () => {
+	test("should generate a link for a block", async () => {
 		assert.is(subject.block("id"), "https://dexplorer.ark.io/block/id");
 	});
 
-	suite("should generate a link for a transaction", async () => {
+	test("should generate a link for a transaction", async () => {
 		assert.is(subject.transaction("id"), "https://dexplorer.ark.io/transaction/id");
 	});
 
-	suite("should generate a link for a wallet", async () => {
+	test("should generate a link for a wallet", async () => {
 		assert.is(subject.wallet("id"), "https://dexplorer.ark.io/wallets/id");
 	});
 });
 
-describe("bind.mainnet", (suite) => {
-	suite.before(async () => {
+describe("bind.mainnet", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(Services.AbstractLinkService, "bind.mainnet");
 	});
 
-	suite("should generate a link for a block", async () => {
+	test("should generate a link for a block", async () => {
 		assert.is(subject.block("id"), "https://bindscan.io/block/id");
 	});
 
-	suite("should generate a link for a transaction", async () => {
+	test("should generate a link for a transaction", async () => {
 		assert.is(subject.transaction("id"), "https://bindscan.io/transaction/id");
 	});
 
-	suite("should generate a link for a wallet", async () => {
+	test("should generate a link for a wallet", async () => {
 		assert.is(subject.wallet("id"), "https://bindscan.io/wallets/id");
 	});
 });
 
-describe("bind.testnet", (suite) => {
-	suite.before(async () => {
+describe("bind.testnet", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(Services.AbstractLinkService, "bind.testnet");
 	});
 
-	suite("should generate a link for a block", async () => {
+	test("should generate a link for a block", async () => {
 		assert.is(subject.block("id"), "https://testnet.bindscan.io/block/id");
 	});
 
-	suite("should generate a link for a transaction", async () => {
+	test("should generate a link for a transaction", async () => {
 		assert.is(subject.transaction("id"), "https://testnet.bindscan.io/transaction/id");
 	});
 
-	suite("should generate a link for a wallet", async () => {
+	test("should generate a link for a wallet", async () => {
 		assert.is(subject.wallet("id"), "https://testnet.bindscan.io/wallets/id");
 	});
 });
 
-describe("xqr.mainnet", (suite) => {
-	suite.before(async () => {
+describe("xqr.mainnet", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(Services.AbstractLinkService, "xqr.mainnet");
 	});
 
-	suite("should generate a link for a block", async () => {
+	test("should generate a link for a block", async () => {
 		assert.is(subject.block("id"), "https://explorer.sh/qredit/block/id");
 	});
 
-	suite("should generate a link for a transaction", async () => {
+	test("should generate a link for a transaction", async () => {
 		assert.is(subject.transaction("id"), "https://explorer.sh/qredit/transaction/id");
 	});
 
-	suite("should generate a link for a wallet", async () => {
+	test("should generate a link for a wallet", async () => {
 		assert.is(subject.wallet("id"), "https://explorer.sh/qredit/wallet/id");
 	});
 });
 
-describe("xqr.testnet", (suite) => {
-	suite.before(async () => {
+describe("xqr.testnet", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(Services.AbstractLinkService, "xqr.testnet");
 	});
 
-	suite("should generate a link for a block", async () => {
+	test("should generate a link for a block", async () => {
 		assert.is(subject.block("id"), "https://explorer.sh/qredit-testnet/block/id");
 	});
 
-	suite("should generate a link for a transaction", async () => {
+	test("should generate a link for a transaction", async () => {
 		assert.is(subject.transaction("id"), "https://explorer.sh/qredit-testnet/transaction/id");
 	});
 
-	suite("should generate a link for a wallet", async () => {
+	test("should generate a link for a wallet", async () => {
 		assert.is(subject.wallet("id"), "https://explorer.sh/qredit-testnet/wallet/id");
 	});
 });
 
-describe("bpl.mainnet", (suite) => {
-	suite.before(async () => {
+describe("bpl.mainnet", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(Services.AbstractLinkService, "bpl.mainnet");
 	});
 
-	suite("should generate a link for a block", async () => {
+	test("should generate a link for a block", async () => {
 		assert.is(subject.block("id"), "https://explorer.blockpool.io/#/block/id");
 	});
 
-	suite("should generate a link for a transaction", async () => {
+	test("should generate a link for a transaction", async () => {
 		assert.is(subject.transaction("id"), "https://explorer.blockpool.io/#/transaction/id");
 	});
 
-	suite("should generate a link for a wallet", async () => {
+	test("should generate a link for a wallet", async () => {
 		assert.is(subject.wallet("id"), "https://explorer.blockpool.io/#/wallets/id");
 	});
 });

--- a/packages/ark/source/wallet.dto.test.js
+++ b/packages/ark/source/wallet.dto.test.js
@@ -77,60 +77,60 @@ const WalletDataFixture = {
 };
 
 for (const network of ["mainnet", "devnet"]) {
-	describe(network, (suite) => {
-		suite.before.each(async () => {
+	describe(network, ({ afterEach, beforeEach, test }) => {
+		beforeEach(async () => {
 			subject = (await createService(WalletData)).fill(WalletDataFixture[network]);
 		});
 
-		suite("#primaryKey", () => {
+		test("#primaryKey", () => {
 			assert.is(subject.primaryKey(), "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9");
 		});
 
-		suite("#address", () => {
+		test("#address", () => {
 			assert.is(subject.address(), "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9");
 		});
 
-		suite("#publicKey", () => {
+		test("#publicKey", () => {
 			assert.is(subject.publicKey(), "03bbfb43ecb5a54a1e227bb37b5812b5321213838d376e2b455b6af78442621dec");
 		});
 
-		suite("#balance", () => {
+		test("#balance", () => {
 			assert.equal(subject.balance().available, BigNumber.make("55827093444556"));
 		});
 
-		suite("#nonce", () => {
+		test("#nonce", () => {
 			assert.equal(subject.nonce(), BigNumber.make("111932"));
 		});
 
-		suite("#secondPublicKey", () => {
+		test("#secondPublicKey", () => {
 			assert.undefined(subject.secondPublicKey());
 		});
 
-		suite("#username", () => {
+		test("#username", () => {
 			assert.is(subject.username(), "arkx");
 		});
 
-		suite("#rank", () => {
+		test("#rank", () => {
 			assert.undefined(subject.rank());
 		});
 
-		suite("#votes", () => {
+		test("#votes", () => {
 			assert.equal(subject.votes(), network === "devnet" ? BigNumber.make(0) : undefined);
 		});
 
-		suite("#isResignedDelegate", () => {
+		test("#isResignedDelegate", () => {
 			assert.boolean(subject.isResignedDelegate());
 		});
 
-		suite("#isMultiSignature", () => {
+		test("#isMultiSignature", () => {
 			assert.boolean(subject.isMultiSignature());
 		});
 
-		suite("#isSecondSignature", () => {
+		test("#isSecondSignature", () => {
 			assert.false(subject.isSecondSignature());
 		});
 
-		suite("#toObject", () => {
+		test("#toObject", () => {
 			assert.object(subject.toObject());
 		});
 	});

--- a/packages/atom/source/client.service.test.js
+++ b/packages/atom/source/client.service.test.js
@@ -90,67 +90,62 @@ test("#wallet", async () => {
 	assert.equal(result.nonce(), BigNumber.make(24242));
 });
 
-describe("#broadcast", () => {
-	const transactionPayload = createService(SignedTransactionData).configure(
-		"id",
-		{
-			msg: [
-				{
-					type: "cosmos-sdk/MsgSend",
-					value: {
-						amount: [{ amount: 1, denom: "umuon" }],
-						from_address: "cosmos1pnc559thh9ks4crsp5p3wta2f2m09t4gluyl2l",
-						to_address: "cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2",
-					},
+const transactionPayload = createService(SignedTransactionData).configure(
+	"id",
+	{
+		msg: [
+			{
+				type: "cosmos-sdk/MsgSend",
+				value: {
+					amount: [{ amount: 1, denom: "umuon" }],
+					from_address: "cosmos1pnc559thh9ks4crsp5p3wta2f2m09t4gluyl2l",
+					to_address: "cosmos1xvt4e7xd0j9dwv2w83g50tpcltsl90h52003e2",
 				},
-			],
-			fee: { amount: [{ amount: 5000, denom: "umuon" }], gas: "200000" },
-			signatures: [
-				{
-					signature:
-						"naiy71Wa8hPC8wMj2/J4CwnqtR8RThv9Cy3y1EGJVowVtDWJQoUmy3KfYneA2wwLQUlgI/UWgNMClCzbJdD8Ew==",
-					account_number: "58976",
-					sequence: "16",
-					pub_key: {
-						type: "tendermint/PubKeySecp256k1",
-						value: "A1wiLscFDRRdEuWx5WmXbXVbMszN2cBHaJFWfJm399Yy",
-					},
-				},
-			],
-			memo: "",
-		},
-		"",
-	);
-
-	test("should pass", async () => {
-		nock("https://stargate.cosmos.network")
-			.post("/txs")
-			.reply(200, loader.json(`test/fixtures/client/broadcast.json`));
-
-		const result = await subject.broadcast([transactionPayload]);
-
-		assert.equal(result, {
-			accepted: ["25E82BD7E457147DA29FD39E6C155365F07559A7834C7FBB4E9B21DE6A65BFC7"],
-			rejected: [],
-			errors: {},
-		});
-	});
-
-	test("should fail", async () => {
-		nock("https://stargate.cosmos.network")
-			.post("/txs")
-			.reply(200, loader.json(`test/fixtures/client/broadcast-failure.json`));
-
-		const result = await subject.broadcast([transactionPayload]);
-
-		assert.equal(result, {
-			accepted: [],
-			rejected: ["535C0F6E94506C2D579CCAC76A155472394062FD2D712C662745D93E951164FB"],
-			errors: {
-				"535C0F6E94506C2D579CCAC76A155472394062FD2D712C662745D93E951164FB":
-					"insufficient account funds; 24929994umuon < 100000000umuon",
 			},
-		});
+		],
+		fee: { amount: [{ amount: 5000, denom: "umuon" }], gas: "200000" },
+		signatures: [
+			{
+				signature: "naiy71Wa8hPC8wMj2/J4CwnqtR8RThv9Cy3y1EGJVowVtDWJQoUmy3KfYneA2wwLQUlgI/UWgNMClCzbJdD8Ew==",
+				account_number: "58976",
+				sequence: "16",
+				pub_key: {
+					type: "tendermint/PubKeySecp256k1",
+					value: "A1wiLscFDRRdEuWx5WmXbXVbMszN2cBHaJFWfJm399Yy",
+				},
+			},
+		],
+		memo: "",
+	},
+	"",
+);
+
+test("broadcast should pass", async () => {
+	nock("https://stargate.cosmos.network").post("/txs").reply(200, loader.json(`test/fixtures/client/broadcast.json`));
+
+	const result = await subject.broadcast([transactionPayload]);
+
+	assert.equal(result, {
+		accepted: ["25E82BD7E457147DA29FD39E6C155365F07559A7834C7FBB4E9B21DE6A65BFC7"],
+		rejected: [],
+		errors: {},
+	});
+});
+
+test("broadcast should fail", async () => {
+	nock("https://stargate.cosmos.network")
+		.post("/txs")
+		.reply(200, loader.json(`test/fixtures/client/broadcast-failure.json`));
+
+	const result = await subject.broadcast([transactionPayload]);
+
+	assert.equal(result, {
+		accepted: [],
+		rejected: ["535C0F6E94506C2D579CCAC76A155472394062FD2D712C662745D93E951164FB"],
+		errors: {
+			"535C0F6E94506C2D579CCAC76A155472394062FD2D712C662745D93E951164FB":
+				"insufficient account funds; 24929994umuon < 100000000umuon",
+		},
 	});
 });
 

--- a/packages/atom/source/ledger.service.test.js
+++ b/packages/atom/source/ledger.service.test.js
@@ -33,7 +33,7 @@ const createMockService = async (record) => {
 	return transport;
 };
 
-describe("disconnect", () => {
+describe("disconnect", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a resolved transport closure", async () => {
 		const subject = await createMockService("");
 
@@ -41,7 +41,7 @@ describe("disconnect", () => {
 	});
 });
 
-describe("getVersion", () => {
+describe("getVersion", ({ afterEach, beforeEach, test }) => {
 	test("should pass with an app version", async () => {
 		const subject = await createMockService(ledger.appVersion.record);
 
@@ -57,7 +57,7 @@ test.skip("getPublicKey", () => {
 	});
 });
 
-describe("signTransaction", () => {
+describe("signTransaction", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a signature", async () => {
 		const subject = await createMockService(ledger.transaction.record);
 
@@ -68,7 +68,7 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signMessage", () => {
+describe("signMessage", ({ afterEach, beforeEach, test }) => {
 	test("should fail with a 'NotImplemented' error", async () => {
 		const subject = await createMockService("");
 

--- a/packages/btc/source/address.service.test.js
+++ b/packages/btc/source/address.service.test.js
@@ -16,14 +16,14 @@ test.before(async () => {
 
 // These tests are based on the values from https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/integration/addresses.spec.ts
 
-describe("#fromMnemonic", (suite) => {
-	suite.before(async () => {
+describe("#fromMnemonic", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(AddressService, undefined, async (container) => {
 			container.singleton(BindingType.AddressFactory, AddressFactory);
 		});
 	});
 
-	suite("should generate an output from a mnemonic (BIP44)", async () => {
+	test("should generate an output from a mnemonic (BIP44)", async () => {
 		const result = await subject.fromMnemonic(identity.mnemonic, { bip44: { account: 0 } });
 
 		assert.is(result.type, "bip44");
@@ -31,7 +31,7 @@ describe("#fromMnemonic", (suite) => {
 		assert.is(result.path, "m/44'/0'/0'/0/0");
 	});
 
-	suite("should generate an output from a mnemonic (BIP49)", async () => {
+	test("should generate an output from a mnemonic (BIP49)", async () => {
 		const result = await subject.fromMnemonic(identity.mnemonic, { bip49: { account: 0 } });
 
 		assert.is(result.type, "bip49");
@@ -39,7 +39,7 @@ describe("#fromMnemonic", (suite) => {
 		assert.is(result.path, "m/49'/0'/0'/0/0");
 	});
 
-	suite("should generate an output from a mnemonic (BIP84)", async () => {
+	test("should generate an output from a mnemonic (BIP84)", async () => {
 		const result = await subject.fromMnemonic(identity.mnemonic, { bip84: { account: 0 } });
 
 		assert.is(result.type, "bip84");
@@ -48,14 +48,14 @@ describe("#fromMnemonic", (suite) => {
 	});
 });
 
-describe("#fromPublicKey", (suite) => {
-	suite.before(async () => {
+describe("#fromPublicKey", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(AddressService, undefined, async (container) => {
 			container.singleton(BindingType.AddressFactory, AddressFactory);
 		});
 	});
 
-	suite("should import an address (via P2PKH)", async () => {
+	test("should import an address (via P2PKH)", async () => {
 		const result = await subject.fromPublicKey(
 			"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
 			{ bip44: { account: 0 } },
@@ -65,7 +65,7 @@ describe("#fromPublicKey", (suite) => {
 		assert.is(result.address, "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH");
 	});
 
-	suite("should fail to generate address if ext pub key is not depth 3", async () => {
+	test("should fail to generate address if ext pub key is not depth 3", async () => {
 		await assert.rejects(() =>
 			subject.fromPublicKey(
 				"xpub6ENuDU6ouVBjsS46mpqzNzaJXs5iuNnhgKb9LWCgCwtK74fnATHwVJvsYYbH7bFUzZSh9PGA4Q9G5465WxHHRNys1hejSwbDZaw9ro5vDtD",
@@ -73,7 +73,7 @@ describe("#fromPublicKey", (suite) => {
 		);
 	});
 
-	suite("should generate a SegWit address (via P2SH)", async () => {
+	test("should generate a SegWit address (via P2SH)", async () => {
 		const result = await subject.fromPublicKey(
 			"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
 			{ bip49: { account: 0 } },
@@ -83,7 +83,7 @@ describe("#fromPublicKey", (suite) => {
 		assert.is(result.address, "3JvL6Ymt8MVWiCNHC7oWU6nLeHNJKLZGLN");
 	});
 
-	suite("should generate a native SegWit address (via P2WPKH)", async () => {
+	test("should generate a native SegWit address (via P2WPKH)", async () => {
 		const result = await subject.fromPublicKey(
 			"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
 			{ bip84: { account: 0 } },
@@ -93,7 +93,7 @@ describe("#fromPublicKey", (suite) => {
 		assert.is(result.address, "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
 	});
 
-	suite("should generate an address from an extended public key for livenet", async () => {
+	test("should generate an address from an extended public key for livenet", async () => {
 		const result = await subject.fromPublicKey(
 			"xpub6Bk8X5Y1FN7pSecqoqkHe8F8gNaqMVApCrmMxZnRvSw4JpgqeM5T83Ze6uD4XEMiCSwZiwysnny8uQj5F6XAPF9FNKYNHTMoAu97bDXNtRe",
 			{ bip44: { account: 0 } },
@@ -103,7 +103,7 @@ describe("#fromPublicKey", (suite) => {
 		assert.is(result.address, "12KRAVpawWmzWNnv9WbqqKRHuhs7nFiQro");
 	});
 
-	suite("should generate a Native SegWit address from an extended public key for tesnet", async () => {
+	test("should generate a Native SegWit address from an extended public key for tesnet", async () => {
 		subject = await createService(AddressService, "btc.testnet", async (container) => {
 			container.singleton(BindingType.AddressFactory, AddressFactory);
 		});
@@ -116,7 +116,7 @@ describe("#fromPublicKey", (suite) => {
 		assert.is(result.address, "tb1q705a7ak4ejlmfc5uq3afg2q45v4yw7kyv8jgsn");
 	});
 
-	suite("should generate a Native SegWit address from an extended public key for livenet", async () => {
+	test("should generate a Native SegWit address from an extended public key for livenet", async () => {
 		subject = await createService(AddressService, "btc.livenet", async (container) => {
 			container.singleton(BindingType.AddressFactory, AddressFactory);
 		});
@@ -130,7 +130,7 @@ describe("#fromPublicKey", (suite) => {
 		assert.is(result.address, "bc1qpeeu3vjrm9dn2y42sl926374y5cvdhfn5k7kxm");
 	});
 
-	suite("should generate a Native SegWit address from an extended public key for testnet", async () => {
+	test("should generate a Native SegWit address from an extended public key for testnet", async () => {
 		subject = await createService(AddressService, "btc.testnet", async (container) => {
 			container.singleton(BindingType.AddressFactory, AddressFactory);
 		});
@@ -145,14 +145,14 @@ describe("#fromPublicKey", (suite) => {
 	});
 });
 
-describe("#fromPrivateKey", (suite) => {
-	suite.before(async () => {
+describe("#fromPrivateKey", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(AddressService, undefined, async (container) => {
 			container.singleton(BindingType.AddressFactory, AddressFactory);
 		});
 	});
 
-	suite("should import an address via WIF", async () => {
+	test("should import an address via WIF", async () => {
 		const result = await subject.fromPrivateKey(
 			"0000000000000000000000000000000000000000000000000000000000000001",
 			{ bip44: { account: 0 } },
@@ -162,7 +162,7 @@ describe("#fromPrivateKey", (suite) => {
 		assert.is(result.address, "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH");
 	});
 
-	suite("should generate a SegWit address (via P2SH)", async () => {
+	test("should generate a SegWit address (via P2SH)", async () => {
 		const result = await subject.fromPrivateKey(
 			"0000000000000000000000000000000000000000000000000000000000000001",
 			{ bip49: { account: 0 } },
@@ -172,7 +172,7 @@ describe("#fromPrivateKey", (suite) => {
 		assert.is(result.address, "3JvL6Ymt8MVWiCNHC7oWU6nLeHNJKLZGLN");
 	});
 
-	suite("should generate a SegWit address", async () => {
+	test("should generate a SegWit address", async () => {
 		const result = await subject.fromPrivateKey(
 			"0000000000000000000000000000000000000000000000000000000000000001",
 			{ bip84: { account: 0 } },
@@ -183,14 +183,14 @@ describe("#fromPrivateKey", (suite) => {
 	});
 });
 
-describe("#fromMultiSignature", (suite) => {
-	suite.before(async () => {
+describe("#fromMultiSignature", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(AddressService, undefined, async (container) => {
 			container.singleton(BindingType.AddressFactory, AddressFactory);
 		});
 	});
 
-	suite("should generate a P2SH, pay-to-multisig (2-of-3) address", async () => {
+	test("should generate a P2SH, pay-to-multisig (2-of-3) address", async () => {
 		const result = await subject.fromMultiSignature(
 			{
 				min: 2,
@@ -208,7 +208,7 @@ describe("#fromMultiSignature", (suite) => {
 		assert.is(result.address, "36NUkt6FWUi3LAWBqWRdDmdTWbt91Yvfu7");
 	});
 
-	suite("should generate a P2SH(P2WSH(...)), pay-to-multisig (2-of-2) address", async () => {
+	test("should generate a P2SH(P2WSH(...)), pay-to-multisig (2-of-2) address", async () => {
 		const result = await subject.fromMultiSignature(
 			{
 				min: 2,
@@ -224,7 +224,7 @@ describe("#fromMultiSignature", (suite) => {
 		assert.is(result.address, "3P4mrxQfmExfhxqjLnR2Ah4WES5EB1KBrN");
 	});
 
-	suite("should generate a P2WSH (SegWit), pay-to-multisig (3-of-4) address", async () => {
+	test("should generate a P2WSH (SegWit), pay-to-multisig (3-of-4) address", async () => {
 		const result = await subject.fromMultiSignature(
 			{
 				min: 3,
@@ -243,14 +243,14 @@ describe("#fromMultiSignature", (suite) => {
 	});
 });
 
-describe("#fromWIF", (suite) => {
-	suite.before(async () => {
+describe("#fromWIF", ({ afterEach, beforeAll, test }) => {
+	beforeAll(async () => {
 		subject = await createService(AddressService, undefined, async (container) => {
 			container.singleton(BindingType.AddressFactory, AddressFactory);
 		});
 	});
 
-	suite("should import an address via WIF", async () => {
+	test("should import an address via WIF", async () => {
 		const result = await subject.fromWIF("KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn", {
 			bip44: { account: 0 },
 		});
@@ -259,7 +259,7 @@ describe("#fromWIF", (suite) => {
 		assert.is(result.address, "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH");
 	});
 
-	suite("should generate a SegWit address (via P2SH)", async () => {
+	test("should generate a SegWit address (via P2SH)", async () => {
 		const result = await subject.fromWIF("KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn", {
 			bip49: { account: 0 },
 		});
@@ -268,7 +268,7 @@ describe("#fromWIF", (suite) => {
 		assert.is(result.address, "3JvL6Ymt8MVWiCNHC7oWU6nLeHNJKLZGLN");
 	});
 
-	suite("should generate a SegWit address", async () => {
+	test("should generate a SegWit address", async () => {
 		const result = await subject.fromWIF("KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn", {
 			bip84: { account: 0 },
 		});

--- a/packages/btc/source/ledger.service.test.js
+++ b/packages/btc/source/ledger.service.test.js
@@ -33,7 +33,7 @@ const createMockService = async (record) => {
 	return transport;
 };
 
-describe("disconnect", async () => {
+test("disconnect", async () => {
 	const subject = await createMockService("");
 
 	assert.undefined(await subject.disconnect());

--- a/packages/btc/source/link.service.test.js
+++ b/packages/btc/source/link.service.test.js
@@ -5,38 +5,38 @@ import { createService } from "../test/mocking";
 
 let subject;
 
-describe("livenet", function (suite) {
-	suite.before(async () => {
+describe("livenet", function ({ afterEach, beforeAll, test }) {
+	beforeAll(async () => {
 		subject = await createService(Services.AbstractLinkService, "btc.livenet");
 	});
 
-	suite("should generate a link for a block", async () => {
+	test("should generate a link for a block", async () => {
 		assert.is(subject.block("id"), "https://blockstream.info/block/id");
 	});
 
-	suite("should generate a link for a transaction", async () => {
+	test("should generate a link for a transaction", async () => {
 		assert.is(subject.transaction("id"), "https://blockstream.info/tx/id");
 	});
 
-	suite("should generate a link for a wallet", async () => {
+	test("should generate a link for a wallet", async () => {
 		assert.is(subject.wallet("id"), "https://blockstream.info/address/id");
 	});
 });
 
-describe("testnet", function (suite) {
-	suite.before(async () => {
+describe("testnet", function ({ afterEach, beforeAll, test }) {
+	beforeAll(async () => {
 		subject = await createService(Services.AbstractLinkService, "btc.testnet");
 	});
 
-	suite("should generate a link for a block", async () => {
+	test("should generate a link for a block", async () => {
 		assert.is(subject.block("id"), "https://blockstream.info/testnet/block/id");
 	});
 
-	suite("should generate a link for a transaction", async () => {
+	test("should generate a link for a transaction", async () => {
 		assert.is(subject.transaction("id"), "https://blockstream.info/testnet/tx/id");
 	});
 
-	suite("should generate a link for a wallet", async () => {
+	test("should generate a link for a wallet", async () => {
 		assert.is(subject.wallet("id"), "https://blockstream.info/testnet/address/id");
 	});
 });

--- a/packages/btc/source/transaction.service.test.js
+++ b/packages/btc/source/transaction.service.test.js
@@ -46,12 +46,12 @@ const createLocalServices = async () => {
 	});
 };
 
-describe("bip44 wallet", (suite) => {
-	suite.after.each(async () => {
+describe("bip44 wallet", ({ afterEach, beforeEach, test }) => {
+	afterEach(async () => {
 		nock.cleanAll();
 	});
 
-	suite.before.each(async () => {
+	beforeEach(async () => {
 		await createLocalServices();
 
 		nock("https://btc-test.payvo.com:443", { encodedQueryParams: true })
@@ -98,7 +98,7 @@ describe("bip44 wallet", (suite) => {
 			.persist();
 	});
 
-	suite("should generate and sign a transfer transaction", async () => {
+	test("should generate and sign a transfer transaction", async () => {
 		const signatory = new Signatories.Signatory(
 			new Signatories.MnemonicSignatory({
 				signingKey: mnemonic,
@@ -133,12 +133,12 @@ describe("bip44 wallet", (suite) => {
 	});
 });
 
-describe("bip49 wallet", (suite) => {
-	suite.after.each(async () => {
+describe("bip49 wallet", ({ afterEach, beforeEach, test }) => {
+	afterEach(async () => {
 		nock.cleanAll();
 	});
 
-	suite.before.each(async () => {
+	beforeEach(async () => {
 		await createLocalServices();
 
 		nock("https://btc-test.payvo.com:443", { encodedQueryParams: true })
@@ -185,7 +185,7 @@ describe("bip49 wallet", (suite) => {
 			.persist();
 	});
 
-	suite("should generate and sign a transfer transaction", async () => {
+	test("should generate and sign a transfer transaction", async () => {
 		const signatory = new Signatories.Signatory(
 			new Signatories.MnemonicSignatory({
 				signingKey: mnemonic,
@@ -221,12 +221,12 @@ describe("bip49 wallet", (suite) => {
 	});
 });
 
-describe("bip84 wallet", (suite) => {
-	suite.after.each(async () => {
+describe("bip84 wallet", ({ afterEach, beforeEach, test }) => {
+	afterEach(async () => {
 		nock.cleanAll();
 	});
 
-	suite.before.each(async () => {
+	beforeEach(async () => {
 		await createLocalServices();
 
 		nock("https://btc-test.payvo.com:443", { encodedQueryParams: true })
@@ -273,7 +273,7 @@ describe("bip84 wallet", (suite) => {
 			.persist();
 	});
 
-	suite("should generate and sign a transfer transaction", async () => {
+	test("should generate and sign a transfer transaction", async () => {
 		const signatory = new Signatories.Signatory(
 			new Signatories.MnemonicSignatory({
 				signingKey: mnemonic,
@@ -309,12 +309,12 @@ describe("bip84 wallet", (suite) => {
 	});
 });
 
-describe("legacy multisignature wallet", (suite) => {
-	suite.after.each(async () => {
+describe("legacy multisignature wallet", ({ afterEach, beforeEach, test }) => {
+	afterEach(async () => {
 		nock.cleanAll();
 	});
 
-	suite.before.each(async () => {
+	beforeEach(async () => {
 		await createLocalServices();
 
 		nock("https://btc-test.payvo.com:443", { encodedQueryParams: true })
@@ -350,7 +350,7 @@ describe("legacy multisignature wallet", (suite) => {
 			.persist();
 	});
 
-	suite("should generate a transfer transaction", async () => {
+	test("should generate a transfer transaction", async () => {
 		const multiSignatureAsset = {
 			min: 2,
 			publicKeys: musig.accounts.map((account) => account.legacyMasterPublicKey),
@@ -381,12 +381,12 @@ describe("legacy multisignature wallet", (suite) => {
 	});
 });
 
-describe("p2sh segwit multisignature wallet", (suite) => {
-	suite.after.each(async () => {
+describe("p2sh segwit multisignature wallet", ({ afterEach, beforeEach, test }) => {
+	afterEach(async () => {
 		nock.cleanAll();
 	});
 
-	suite.before.each(async () => {
+	beforeEach(async () => {
 		await createLocalServices();
 
 		nock("https://btc-test.payvo.com:443", { encodedQueryParams: true })
@@ -422,7 +422,7 @@ describe("p2sh segwit multisignature wallet", (suite) => {
 			.persist();
 	});
 
-	suite("should generate a transfer transaction", async () => {
+	test("should generate a transfer transaction", async () => {
 		const multiSignatureAsset = {
 			min: 2,
 			publicKeys: musig.accounts.map((account) => account.p2shSegwitMasterPublicKey),
@@ -453,12 +453,12 @@ describe("p2sh segwit multisignature wallet", (suite) => {
 	});
 });
 
-describe("native segwit multisignature wallet", (suite) => {
-	suite.after.each(async () => {
+describe("native segwit multisignature wallet", ({ afterEach, beforeEach, test }) => {
+	afterEach(async () => {
 		nock.cleanAll();
 	});
 
-	suite.before.each(async () => {
+	beforeEach(async () => {
 		await createLocalServices();
 
 		nock("https://btc-test.payvo.com:443", { encodedQueryParams: true })
@@ -505,7 +505,7 @@ describe("native segwit multisignature wallet", (suite) => {
 			.persist();
 	});
 
-	suite("should generate a transfer transaction", async () => {
+	test("should generate a transfer transaction", async () => {
 		const multiSignatureAsset = {
 			min: 2,
 			publicKeys: musig.accounts.map((account) => account.nativeSegwitMasterPublicKey),

--- a/packages/btc/source/wallet-discovery.service.test.js
+++ b/packages/btc/source/wallet-discovery.service.test.js
@@ -13,14 +13,14 @@ test.before(async () => {
 	nock.disableNetConnect();
 });
 
-describe("testnet", (suite) => {
-	suite.before.each(async () => {
+describe("testnet", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(WalletDiscoveryService, "btc.testnet", (container) => {
 			container.singleton(BindingType.AddressFactory, AddressFactory);
 		});
 	});
 
-	suite("should generate an output from a mnemonic", async () => {
+	test("should generate an output from a mnemonic", async () => {
 		const result = await subject.fromMnemonic(identity.mnemonic);
 
 		assert.equal(result, [
@@ -42,7 +42,7 @@ describe("testnet", (suite) => {
 		]);
 	});
 
-	suite("should generate an output from a mnemonic for specific paths for each addressing schema", async () => {
+	test("should generate an output from a mnemonic for specific paths for each addressing schema", async () => {
 		const result = await subject.fromMnemonic(identity.mnemonic, {
 			bip44: {
 				account: 7,
@@ -80,7 +80,7 @@ describe("testnet", (suite) => {
 		]);
 	});
 
-	suite("should generate an output from a mnemonic for change chain", async () => {
+	test("should generate an output from a mnemonic for change chain", async () => {
 		const result = await subject.fromMnemonic(identity.mnemonic, {
 			bip44: {
 				account: 5,
@@ -119,14 +119,14 @@ describe("testnet", (suite) => {
 	});
 });
 
-describe("livenet", (suite) => {
-	suite.before.each(async () => {
+describe("livenet", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
 		subject = await createService(WalletDiscoveryService, "btc.livenet", (container) => {
 			container.singleton(BindingType.AddressFactory, AddressFactory);
 		});
 	});
 
-	suite("should generate an output from a mnemonic", async () => {
+	test("should generate an output from a mnemonic", async () => {
 		const result = await subject.fromMnemonic(identity.mnemonic);
 
 		assert.equal(result, [
@@ -148,7 +148,7 @@ describe("livenet", (suite) => {
 		]);
 	});
 
-	suite("should generate an output from a mnemonic for specific paths for each addressing schema", async () => {
+	test("should generate an output from a mnemonic for specific paths for each addressing schema", async () => {
 		const result = await subject.fromMnemonic(identity.mnemonic, {
 			bip44: {
 				account: 7,
@@ -186,7 +186,7 @@ describe("livenet", (suite) => {
 		]);
 	});
 
-	suite("should generate an output from a mnemonic for change chain", async () => {
+	test("should generate an output from a mnemonic for change chain", async () => {
 		const result = await subject.fromMnemonic(identity.mnemonic, {
 			bip44: {
 				account: 5,

--- a/packages/dot/source/ledger.service.test.js
+++ b/packages/dot/source/ledger.service.test.js
@@ -33,7 +33,7 @@ const createMockService = async (record) => {
 	return transport;
 };
 
-describe("disconnect", () => {
+describe("disconnect", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a resolved transport closure", async () => {
 		const subject = await createMockService("");
 
@@ -41,7 +41,7 @@ describe("disconnect", () => {
 	});
 });
 
-describe("getVersion", () => {
+describe("getVersion", ({ afterEach, beforeEach, test }) => {
 	test("should generate an app version", async () => {
 		const polkadot = await createMockService(ledger.appVersion.record);
 
@@ -49,7 +49,7 @@ describe("getVersion", () => {
 	});
 });
 
-describe("getPublicKey", () => {
+describe("getPublicKey", ({ afterEach, beforeEach, test }) => {
 	test("should generate a publicKey", async () => {
 		const polkadot = await createMockService(ledger.publicKey.record);
 
@@ -57,7 +57,7 @@ describe("getPublicKey", () => {
 	});
 });
 
-describe("signTransaction", () => {
+describe("signTransaction", ({ afterEach, beforeEach, test }) => {
 	test("should generate output from a transaction", async () => {
 		const polkadot = await createMockService(ledger.transaction.record);
 
@@ -68,7 +68,7 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signMessage", () => {
+describe("signMessage", ({ afterEach, beforeEach, test }) => {
 	test("should fail to generate an output from a message", async () => {
 		const polkadot = await createMockService("");
 

--- a/packages/eos/source/ledger.service.test.js
+++ b/packages/eos/source/ledger.service.test.js
@@ -33,7 +33,7 @@ const createMockService = async (record) => {
 	return transport;
 };
 
-describe("disconnect", () => {
+describe("disconnect", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a resolved transport closure", async () => {
 		const subject = await createMockService("");
 
@@ -41,7 +41,7 @@ describe("disconnect", () => {
 	});
 });
 
-describe("disconnect", () => {
+describe("disconnect", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a resolved transport closure", async () => {
 		const subject = await createMockService("");
 
@@ -49,7 +49,7 @@ describe("disconnect", () => {
 	});
 });
 
-describe("getVersion", () => {
+describe("getVersion", ({ afterEach, beforeEach, test }) => {
 	test("should pass with an app version", async () => {
 		const subject = await createMockService(ledger.appVersion.record);
 
@@ -76,7 +76,7 @@ test.skip("signTransaction", () => {
 	});
 });
 
-describe("signMessage", () => {
+describe("signMessage", ({ afterEach, beforeEach, test }) => {
 	test("should fail with a 'NotImplemented' error", async () => {
 		const subject = await createMockService("");
 

--- a/packages/eth/source/client.service.test.js
+++ b/packages/eth/source/client.service.test.js
@@ -31,98 +31,86 @@ test.before(async () => {
 	nock.disableNetConnect();
 });
 
-describe("ClientService", () => {
-	describe("#transaction", () => {
-		test("should succeed", async () => {
-			nock("https://platform.ark.io/api/eth")
-				.get("/transactions/0xf6ad7f16653a2070f36c5f9c243acb30109da76658b54712745136d8e8236eae")
-				.reply(200, loader.json(`test/fixtures/client/transaction.json`));
+test("#transaction", async ({ afterEach, beforeEach, test }) => {
+	nock("https://platform.ark.io/api/eth")
+		.get("/transactions/0xf6ad7f16653a2070f36c5f9c243acb30109da76658b54712745136d8e8236eae")
+		.reply(200, loader.json(`test/fixtures/client/transaction.json`));
 
-			const result = await subject.transaction(
-				"0xf6ad7f16653a2070f36c5f9c243acb30109da76658b54712745136d8e8236eae",
-			);
+	const result = await subject.transaction("0xf6ad7f16653a2070f36c5f9c243acb30109da76658b54712745136d8e8236eae");
 
-			assert.instance(result, ConfirmedTransactionData);
-			assert.is(result.id(), "0xf6ad7f16653a2070f36c5f9c243acb30109da76658b54712745136d8e8236eae");
-			assert.is(result.type(), "transfer");
-			assert.undefined(result.timestamp());
-			assert.equal(result.confirmations(), BigNumber.ZERO);
-			assert.is(result.sender(), "0xac1a0f50604c430c25a9fa52078f7f7ec9523519");
-			assert.is(result.recipient(), "0xb5663d3a23706eb4537ffea78f56948a53ac2ebe");
-			assert.is(result.amount().toString(), "10000000000000000000");
-			assert.is(result.fee().toString(), "28000");
-			assert.undefined(result.memo());
-		});
+	assert.instance(result, ConfirmedTransactionData);
+	assert.is(result.id(), "0xf6ad7f16653a2070f36c5f9c243acb30109da76658b54712745136d8e8236eae");
+	assert.is(result.type(), "transfer");
+	assert.undefined(result.timestamp());
+	assert.equal(result.confirmations(), BigNumber.ZERO);
+	assert.is(result.sender(), "0xac1a0f50604c430c25a9fa52078f7f7ec9523519");
+	assert.is(result.recipient(), "0xb5663d3a23706eb4537ffea78f56948a53ac2ebe");
+	assert.is(result.amount().toString(), "10000000000000000000");
+	assert.is(result.fee().toString(), "28000");
+	assert.undefined(result.memo());
+});
+
+test("#transactions", async ({ afterEach, beforeEach, test }) => {
+	nock("https://platform.ark.io/api/eth")
+		.get("/wallets/0x8e5231be3b71afdd0c417164986573fecddbae59/transactions")
+		.reply(200, loader.json(`test/fixtures/client/transactions.json`));
+
+	const result = await subject.transactions({
+		identifiers: [{ type: "address", value: "0x8e5231be3b71afdd0c417164986573fecddbae59" }],
+		limit: 1,
 	});
 
-	describe("#transactions", () => {
-		test("should succeed", async () => {
-			nock("https://platform.ark.io/api/eth")
-				.get("/wallets/0x8e5231be3b71afdd0c417164986573fecddbae59/transactions")
-				.reply(200, loader.json(`test/fixtures/client/transactions.json`));
+	assert.instance(result.items()[0], ConfirmedTransactionData);
+});
 
-			const result = await subject.transactions({
-				identifiers: [{ type: "address", value: "0x8e5231be3b71afdd0c417164986573fecddbae59" }],
-				limit: 1,
-			});
+test("#wallet", async ({ afterEach, beforeEach, test }) => {
+	nock("https://platform.ark.io/api/eth")
+		.get("/wallets/0x4581a610f96878266008993475f1476ca9997081")
+		.reply(200, loader.json(`test/fixtures/client/wallet.json`));
 
-			assert.instance(result.items()[0], ConfirmedTransactionData);
-		});
+	const result = await subject.wallet({
+		type: "address",
+		value: "0x4581a610f96878266008993475f1476ca9997081",
 	});
 
-	describe("#wallet", () => {
-		test("should succeed", async () => {
-			nock("https://platform.ark.io/api/eth")
-				.get("/wallets/0x4581a610f96878266008993475f1476ca9997081")
-				.reply(200, loader.json(`test/fixtures/client/wallet.json`));
+	assert.instance(result, WalletData);
+	assert.is(result.address(), "0xb5663d3a23706eb4537ffea78f56948a53ac2ebe");
+	assert.object(result.balance());
+	assert.is(result.nonce().toString(), "665");
+});
 
-			const result = await subject.wallet({
-				type: "address",
-				value: "0x4581a610f96878266008993475f1476ca9997081",
-			});
+test("broadcast should pass", async () => {
+	nock("https://platform.ark.io/api/eth")
+		.post("/transactions")
+		.reply(200, loader.json(`test/fixtures/client/broadcast.json`));
 
-			assert.instance(result, WalletData);
-			assert.is(result.address(), "0xb5663d3a23706eb4537ffea78f56948a53ac2ebe");
-			assert.object(result.balance());
-			assert.is(result.nonce().toString(), "665");
-		});
+	const result = await subject.broadcast([
+		createService(SignedTransactionData).configure("id", "transactionPayload", "transactionPayload"),
+	]);
+
+	assert.equal(result, {
+		accepted: ["0x227cff6fc8990fecd43cc9c7768f2c98cc5ee8e7c98c67c11161e008cce2b172"],
+		rejected: [],
+		errors: {},
 	});
+});
 
-	describe("#broadcast", () => {
-		test("should pass", async () => {
-			nock("https://platform.ark.io/api/eth")
-				.post("/transactions")
-				.reply(200, loader.json(`test/fixtures/client/broadcast.json`));
+test("broadcast should fail", async () => {
+	nock("https://platform.ark.io/api/eth")
+		.post("/transactions")
+		.reply(200, loader.json(`test/fixtures/client/broadcast-failure.json`));
 
-			const result = await subject.broadcast([
-				createService(SignedTransactionData).configure("id", "transactionPayload", "transactionPayload"),
-			]);
+	const result = await subject.broadcast([
+		createService(SignedTransactionData).configure("id", "transactionPayload", "transactionPayload"),
+	]);
 
-			assert.equal(result, {
-				accepted: ["0x227cff6fc8990fecd43cc9c7768f2c98cc5ee8e7c98c67c11161e008cce2b172"],
-				rejected: [],
-				errors: {},
-			});
-		});
-
-		test("should fail", async () => {
-			nock("https://platform.ark.io/api/eth")
-				.post("/transactions")
-				.reply(200, loader.json(`test/fixtures/client/broadcast-failure.json`));
-
-			const result = await subject.broadcast([
-				createService(SignedTransactionData).configure("id", "transactionPayload", "transactionPayload"),
-			]);
-
-			assert.equal(result, {
-				accepted: [],
-				rejected: ["0x227cff6fc8990fecd43cc9c7768f2c98cc5ee8e7c98c67c11161e008cce2b172"],
-				errors: {
-					"0x227cff6fc8990fecd43cc9c7768f2c98cc5ee8e7c98c67c11161e008cce2b172":
-						"insufficient funds for gas * price + value",
-				},
-			});
-		});
+	assert.equal(result, {
+		accepted: [],
+		rejected: ["0x227cff6fc8990fecd43cc9c7768f2c98cc5ee8e7c98c67c11161e008cce2b172"],
+		errors: {
+			"0x227cff6fc8990fecd43cc9c7768f2c98cc5ee8e7c98c67c11161e008cce2b172":
+				"insufficient funds for gas * price + value",
+		},
 	});
 });
 

--- a/packages/eth/source/ledger.service.test.js
+++ b/packages/eth/source/ledger.service.test.js
@@ -33,7 +33,7 @@ const createMockService = async (record) => {
 	return transport;
 };
 
-describe("disconnect", () => {
+describe("disconnect", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a resolved transport closure", async () => {
 		const trx = await createMockService("");
 
@@ -41,7 +41,7 @@ describe("disconnect", () => {
 	});
 });
 
-describe("getVersion", () => {
+describe("getVersion", ({ afterEach, beforeEach, test }) => {
 	test("should pass with an app version", async () => {
 		const trx = await createMockService(ledger.appVersion.record);
 
@@ -49,7 +49,7 @@ describe("getVersion", () => {
 	});
 });
 
-describe("getPublicKey", () => {
+describe("getPublicKey", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a compressed publicKey", async () => {
 		const trx = await createMockService(ledger.publicKey.record);
 
@@ -57,7 +57,7 @@ describe("getPublicKey", () => {
 	});
 });
 
-describe("signTransaction", () => {
+describe("signTransaction", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a signature", async () => {
 		const trx = await createMockService(ledger.transaction.record);
 
@@ -67,7 +67,7 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signMessage", () => {
+describe("signMessage", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a signature", async () => {
 		const trx = await createMockService(ledger.message.record);
 

--- a/packages/eth/source/private-key.service.test.js
+++ b/packages/eth/source/private-key.service.test.js
@@ -9,12 +9,10 @@ test.before.each(async () => {
 	subject = await createService(PrivateKeyService);
 });
 
-describe("PrivateKey", () => {
-	test("should generate an output from a mnemonic", async () => {
-		const result = await subject.fromMnemonic(identity.mnemonic);
+test("should generate an output from a mnemonic", async () => {
+	const result = await subject.fromMnemonic(identity.mnemonic);
 
-		assert.equal(result, { privateKey: identity.privateKey });
-	});
+	assert.equal(result, { privateKey: identity.privateKey });
 });
 
 test.run();

--- a/packages/lsk/source/asset.serializer.test.js
+++ b/packages/lsk/source/asset.serializer.test.js
@@ -2,7 +2,7 @@ import { assert, describe, test } from "@payvo/sdk-test";
 import { createService } from "../test/mocking";
 import { AssetSerializer } from "./asset.serializer";
 
-describe("AssetSerializer #toMachine", () => {
+describe("AssetSerializer #toMachine", ({ afterEach, beforeEach, test }) => {
 	for (const { moduleID, assetID, asset } of [
 		{
 			moduleID: 2,

--- a/packages/lsk/source/client.service.test.js
+++ b/packages/lsk/source/client.service.test.js
@@ -210,10 +210,10 @@ test("#votes", async () => {
 	assert.array(result.votes);
 });
 
-describe("#unlockableBalances", (suite) => {
-	test.before.each(async () => createLocalServices());
+describe("#unlockableBalances", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => createLocalServices());
 
-	suite('#should return empty when the property "unlocking" is missing in the response', async () => {
+	test('#should return empty when the property "unlocking" is missing in the response', async () => {
 		await createLocalServices();
 
 		nock(/.+/)
@@ -243,7 +243,7 @@ describe("#unlockableBalances", (suite) => {
 		assert.array(objects);
 	});
 
-	suite("should have a pending balance if the current height is not greater than the unlock height", async () => {
+	test("should have a pending balance if the current height is not greater than the unlock height", async () => {
 		await createLocalServices();
 
 		// mockery(DateTime, "make").mockReturnValueOnce(DateTime.make("2021-07-28 12:00"));
@@ -286,58 +286,55 @@ describe("#unlockableBalances", (suite) => {
 		assert.is(pending.toHuman(), 10);
 	});
 
-	suite(
-		"should have a current balance if the current height is greater than or equal to the unlock height",
-		async () => {
-			await createLocalServices();
+	test("should have a current balance if the current height is greater than or equal to the unlock height", async () => {
+		await createLocalServices();
 
-			// mockery(DateTime, "make").mockReturnValueOnce(DateTime.make("2021-07-28 12:00"));
+		// mockery(DateTime, "make").mockReturnValueOnce(DateTime.make("2021-07-28 12:00"));
 
-			nock(/.+/)
-				.get("/api/v2/accounts")
-				.query(true)
-				.reply(200, {
-					data: [
-						{
-							dpos: {
-								unlocking: [
-									{
-										delegateAddress: "lsknnwoty8tmzoc96rscwu7bw4kmcwvdatawerehw",
-										amount: "1000000000",
-										height: {
-											start: 14216291,
-											end: 14218291,
-										},
+		nock(/.+/)
+			.get("/api/v2/accounts")
+			.query(true)
+			.reply(200, {
+				data: [
+					{
+						dpos: {
+							unlocking: [
+								{
+									delegateAddress: "lsknnwoty8tmzoc96rscwu7bw4kmcwvdatawerehw",
+									amount: "1000000000",
+									height: {
+										start: 14216291,
+										end: 14218291,
 									},
-								],
-							},
+								},
+							],
 						},
-					],
-				})
-				.get("/api/v2/network/status")
-				.reply(200, {
-					data: {
-						blockTime: 10,
-						height: 14218295,
 					},
-				});
+				],
+			})
+			.get("/api/v2/network/status")
+			.reply(200, {
+				data: {
+					blockTime: 10,
+					height: 14218295,
+				},
+			});
 
-			const { current, pending, objects } = await subject.unlockableBalances(
-				"lskbps7ge5n9y7f8nk4222c77zkqcntrj7jyhmkwp",
-			);
+		const { current, pending, objects } = await subject.unlockableBalances(
+			"lskbps7ge5n9y7f8nk4222c77zkqcntrj7jyhmkwp",
+		);
 
-			assert.is(current.toHuman(), 10);
-			assert.is(pending.toHuman(), 0);
-			assert.array(objects);
-			assert.is(objects[0].amount.toHuman(), 10);
-		},
-	);
+		assert.is(current.toHuman(), 10);
+		assert.is(pending.toHuman(), 0);
+		assert.array(objects);
+		assert.is(objects[0].amount.toHuman(), 10);
+	});
 });
 
-describe("#broadcast", (suite) => {
+describe("#broadcast", ({ afterEach, beforeEach, test }) => {
 	let transactionPayload;
 
-	suite.before.each(async () => {
+	beforeEach(async () => {
 		await createLocalServices();
 
 		const transactionSigned = {
@@ -360,7 +357,7 @@ describe("#broadcast", (suite) => {
 		);
 	});
 
-	suite("should pass", async () => {
+	test("should pass", async () => {
 		nock(/.+/).post("/api/v2/transactions").reply(200, loader.json(`test/fixtures/client/broadcast.json`));
 
 		const result = await subject.broadcast([transactionPayload]);
@@ -372,7 +369,7 @@ describe("#broadcast", (suite) => {
 		});
 	});
 
-	suite("should fail", async () => {
+	test("should fail", async () => {
 		nock(/.+/).post("/api/v2/transactions").reply(200, loader.json(`test/fixtures/client/broadcast-failure.json`));
 
 		const result = await subject.broadcast([transactionPayload]);
@@ -386,7 +383,7 @@ describe("#broadcast", (suite) => {
 		});
 	});
 
-	suite("should handle http exception", async () => {
+	test("should handle http exception", async () => {
 		nock(/.+/).post("/api/v2/transactions").reply(500, { message: "unknown error" });
 
 		const result = await subject.broadcast([transactionPayload]);

--- a/packages/lsk/source/fee.service.test.js
+++ b/packages/lsk/source/fee.service.test.js
@@ -47,36 +47,53 @@ test.before.each(async () => {
 	});
 });
 
-describe("#all", () => {
-	test("should succeed", async () => {
-		const result = await subject.all();
+test("#all should succeed", async () => {
+	const result = await subject.all();
 
-		assert.containKeys(result, [
-			"transfer",
-			"secondSignature",
-			"delegateRegistration",
-			"vote",
-			"multiSignature",
-			"ipfs",
-			"multiPayment",
-			"delegateResignation",
-			"htlcLock",
-			"htlcClaim",
-			"htlcRefund",
-		]);
+	assert.containKeys(result, [
+		"transfer",
+		"secondSignature",
+		"delegateRegistration",
+		"vote",
+		"multiSignature",
+		"ipfs",
+		"multiPayment",
+		"delegateResignation",
+		"htlcLock",
+		"htlcClaim",
+		"htlcRefund",
+	]);
 
-		assert.is(result.transfer.min.toString(), "10000000");
-		assert.is(result.transfer.avg.toString(), "10000000");
-		assert.is(result.transfer.max.toString(), "10000000");
-		assert.is(result.transfer.static.toString(), "10000000");
-	});
+	assert.is(result.transfer.min.toString(), "10000000");
+	assert.is(result.transfer.avg.toString(), "10000000");
+	assert.is(result.transfer.max.toString(), "10000000");
+	assert.is(result.transfer.static.toString(), "10000000");
 });
 
-describe("#calculate", () => {
+describe("#calculate", ({ beforeEach, test }) => {
 	let service;
 
-	test.before.each(async () => {
+	beforeEach(async () => {
 		nock(/.+/).get("/api/v2/fees").reply(200, loader.json(`test/fixtures/client/fees.json`)).persist();
+
+		subject = await createService(FeeService, "lsk.testnet", (container) => {
+			container.constant(IoC.BindingType.Container, container);
+			container.singleton(IoC.BindingType.AddressService, AddressService);
+			container.singleton(IoC.BindingType.ClientService, ClientService);
+			container.constant(IoC.BindingType.DataTransferObjects, {
+				SignedTransactionData,
+				ConfirmedTransactionData,
+				WalletData,
+			});
+			container.singleton(IoC.BindingType.DataTransferObjectService, Services.AbstractDataTransferObjectService);
+			container.singleton(IoC.BindingType.KeyPairService, KeyPairService);
+			container.constant(IoC.BindingType.LedgerTransportFactory, async () => {});
+			container.singleton(IoC.BindingType.LedgerService, LedgerService);
+			container.singleton(IoC.BindingType.PublicKeyService, PublicKeyService);
+			container.singleton(IoC.BindingType.MultiSignatureService, MultiSignatureService);
+			container.singleton(BindingType.AssetSerializer, AssetSerializer);
+			container.singleton(BindingType.TransactionSerializer, TransactionSerializer);
+		});
 
 		service = await createService(TransactionService, "lsk.testnet", (container) => {
 			container.constant(IoC.BindingType.Container, container);

--- a/packages/lsk/source/ledger.service.test.js
+++ b/packages/lsk/source/ledger.service.test.js
@@ -39,7 +39,7 @@ const createMockService = async (record) => {
 	return transport;
 };
 
-describe("connect", () => {
+describe("connect", ({ afterEach, beforeEach, test }) => {
 	test("should throw error with unexpected input", async () => {
 		const transport = await createService(LedgerService, "lsk.mainnet", (container) => {
 			container.constant(IoC.BindingType.Container, container);
@@ -62,7 +62,7 @@ describe("connect", () => {
 	});
 });
 
-describe("disconnect", () => {
+describe("disconnect", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a resolved transport closure", async () => {
 		const lsk = await createMockService("");
 
@@ -70,7 +70,7 @@ describe("disconnect", () => {
 	});
 });
 
-describe("getVersion", () => {
+describe("getVersion", ({ afterEach, beforeEach, test }) => {
 	test("should pass with an app version", async () => {
 		const lsk = await createMockService(ledger.appVersion.record);
 
@@ -78,7 +78,7 @@ describe("getVersion", () => {
 	});
 });
 
-describe("getPublicKey", () => {
+describe("getPublicKey", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a compressed publicKey", async () => {
 		const lsk = await createMockService(ledger.publicKey.record);
 
@@ -86,7 +86,7 @@ describe("getPublicKey", () => {
 	});
 });
 
-describe("signTransaction", () => {
+describe("signTransaction", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a signature", async () => {
 		const lsk = await createMockService(ledger.transaction.record);
 
@@ -97,7 +97,7 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signMessage", () => {
+describe("signMessage", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a signature", async () => {
 		const lsk = await createMockService(ledger.message.record);
 
@@ -108,12 +108,12 @@ describe("signMessage", () => {
 	});
 });
 
-describe("scan", (suite) => {
-	suite.after.each(() => nock.cleanAll());
+describe("scan", ({ afterEach, beforeAll, test }) => {
+	afterEach(() => nock.cleanAll());
 
-	suite.before(() => nock.disableNetConnect());
+	beforeAll(() => nock.disableNetConnect());
 
-	suite("should return scanned wallet", async () => {
+	test("should return scanned wallet", async () => {
 		nock(/.+/)
 			.get("/api/v2/accounts")
 			.query({ address: "lsk8s6v2pdnxvab9oc42wbhvtb569jqg2ubjxgvvj" })
@@ -132,7 +132,7 @@ describe("scan", (suite) => {
 		assert.length(Object.keys(walletData), 4); // 3 + 1 cold wallet
 	});
 
-	suite("should allow to pass a startPath", async () => {
+	test("should allow to pass a startPath", async () => {
 		const lsk = await createMockService(ledger.wallets.record2);
 
 		const walletData = await lsk.scan({ startPath: "44'/134'/10'/0/0" });
@@ -140,7 +140,7 @@ describe("scan", (suite) => {
 		assert.length(Object.keys(walletData), 1);
 	});
 
-	suite("should support legacy", async () => {
+	test("should support legacy", async () => {
 		const lsk = await createMockService(ledger.wallets.record);
 
 		const walletData = await lsk.scan({ useLegacy: true });

--- a/packages/lsk/source/multi-signature.service.test.js
+++ b/packages/lsk/source/multi-signature.service.test.js
@@ -142,10 +142,10 @@ test("should add signature", async () => {
 	assert.false(musig.needsWalletSignature(transaction2, wallet2.publicKey));
 });
 
-describe("#broadcast", (suite) => {
+describe("#broadcast", ({ afterEach, beforeEach, test }) => {
 	let transaction;
 
-	suite.before.each(async () => {
+	beforeEach(async () => {
 		await createLocalServices();
 
 		transaction = await musig.addSignature(
@@ -177,7 +177,7 @@ describe("#broadcast", (suite) => {
 		);
 	});
 
-	suite("should broadcast a transaction", async () => {
+	test("should broadcast a transaction", async () => {
 		nock(/.+/)
 			.post("/", (body) => body.method === "store")
 			.reply(200, {
@@ -191,7 +191,7 @@ describe("#broadcast", (suite) => {
 		});
 	});
 
-	suite("should handle error", async () => {
+	test("should handle error", async () => {
 		nock(/.+/)
 			.post("/", (body) => body.method === "store")
 			.reply(400, {
@@ -207,7 +207,7 @@ describe("#broadcast", (suite) => {
 		});
 	});
 
-	suite("#needsFinalSignature", async () => {
+	test("#needsFinalSignature", async () => {
 		assert.true(
 			musig.needsFinalSignature(
 				await subject.transfer({
@@ -229,7 +229,7 @@ describe("#broadcast", (suite) => {
 		);
 	});
 
-	suite("#allWithPendingState", async () => {
+	test("#allWithPendingState", async () => {
 		nock(/.+/)
 			.post("/", {
 				jsonrpc: "2.0",
@@ -250,7 +250,7 @@ describe("#broadcast", (suite) => {
 		await assert.length(await musig.allWithPendingState(identity.publicKey), 2);
 	});
 
-	suite("#allWithReadyState", async () => {
+	test("#allWithReadyState", async () => {
 		nock(/.+/)
 			.post("/", {
 				jsonrpc: "2.0",
@@ -271,7 +271,7 @@ describe("#broadcast", (suite) => {
 		assert.length(await musig.allWithReadyState(identity.publicKey), 2);
 	});
 
-	suite("#findById", async () => {
+	test("#findById", async () => {
 		nock(/.+/)
 			.post("/", {
 				jsonrpc: "2.0",
@@ -288,7 +288,7 @@ describe("#broadcast", (suite) => {
 		});
 	});
 
-	suite("#forgetById", async () => {
+	test("#forgetById", async () => {
 		const deleteNock = nock(/.+/)
 			.post("/", {
 				jsonrpc: "2.0",

--- a/packages/lsk/source/multi-signature.transaction.test.js
+++ b/packages/lsk/source/multi-signature.transaction.test.js
@@ -130,7 +130,7 @@ test("#isMultiSignatureReady", () => {
 	assert.true(new PendingMultiSignatureTransaction(register3).isMultiSignatureReady({ excludeFinal: false }));
 });
 
-describe("#needsSignatures", () => {
+describe("#needsSignatures", ({ afterEach, beforeEach, test }) => {
 	test("should return false if it is not a multi signature transaction", () => {
 		assert.false(new PendingMultiSignatureTransaction({ ...transfer1, signatures: undefined }).needsSignatures());
 	});
@@ -154,7 +154,7 @@ test("#needsAllSignatures", () => {
 	assert.false(new PendingMultiSignatureTransaction(register3).needsAllSignatures());
 });
 
-describe("#needsWalletSignature", () => {
+describe("#needsWalletSignature", ({ afterEach, beforeEach, test }) => {
 	test("should return false if it is not a multi signature transaction", () => {
 		assert.false(
 			new PendingMultiSignatureTransaction({ ...transfer1, signatures: undefined }).needsWalletSignature(wallet1),
@@ -180,7 +180,7 @@ describe("#needsWalletSignature", () => {
 	});
 });
 
-describe("#needsFinalSignature", () => {
+describe("#needsFinalSignature", ({ afterEach, beforeEach, test }) => {
 	test("should return false if it is not a multi signature transaction", () => {
 		assert.false(
 			new PendingMultiSignatureTransaction({ ...transfer1, signatures: undefined }).needsFinalSignature(),

--- a/packages/lsk/source/signed-transaction.dto.test.js
+++ b/packages/lsk/source/signed-transaction.dto.test.js
@@ -1,4 +1,4 @@
-import { assert, describe, test } from "@payvo/sdk-test";
+import { assert, test } from "@payvo/sdk-test";
 import { DateTime } from "@payvo/sdk-intl";
 import { BigNumber } from "@payvo/sdk-helpers";
 
@@ -34,63 +34,59 @@ test("#sender", () => {
 	assert.is(subject.sender(), transaction.asset.recipientAddress);
 });
 
-describe("#recipient", () => {
-	test("returns the recipient address", () => {
-		assert.is(subject.recipient(), transaction.asset.recipientAddress);
-	});
-
-	test("returns the recipient address when it's buffer", async () => {
-		subject = await createService(SignedTransactionData).configure(
-			transaction.id,
-			{
-				...transaction,
-				asset: {
-					recipientAddress: Buffer.from([
-						118, 60, 25, 27, 10, 77, 5, 117, 2, 12, 225, 230, 80, 3, 117, 214, 208, 189, 212, 94,
-					]),
-				},
-			},
-			transaction,
-		);
-
-		assert.is(subject.recipient(), "lsk72fxrb264kvw6zuojntmzzsqds35sqvfzz76d7");
-	});
+test("returns the recipient address", () => {
+	assert.is(subject.recipient(), transaction.asset.recipientAddress);
 });
 
-describe("#amount", () => {
-	test("returns transaction amount", () => {
-		assert.instance(subject.amount(), BigNumber);
-		assert.is(subject.amount().toString(), "100000000");
-	});
-
-	test("returns sum of unlock objects amounts if type is unlockToken", async () => {
-		subject = await createService(SignedTransactionData).configure(
-			transaction.id,
-			{
-				...transaction,
-				moduleID: 5,
-				assetID: 2,
-				asset: {
-					unlockObjects: [
-						{
-							delegateAddress: "lskc579agejjw3fo9nvgg85r8vo6sa5xojtw9qscj",
-							amount: "2000000000",
-							unvoteHeight: 14548930,
-						},
-						{
-							delegateAddress: "8c955e70d0da3e0424abc4c0683280232f41c48b",
-							amount: "3000000000",
-							unvoteHeight: 14548929,
-						},
-					],
-				},
+test("returns the recipient address when it's buffer", async () => {
+	subject = await createService(SignedTransactionData).configure(
+		transaction.id,
+		{
+			...transaction,
+			asset: {
+				recipientAddress: Buffer.from([
+					118, 60, 25, 27, 10, 77, 5, 117, 2, 12, 225, 230, 80, 3, 117, 214, 208, 189, 212, 94,
+				]),
 			},
-			transaction,
-		);
+		},
+		transaction,
+	);
 
-		assert.instance(subject.amount(), BigNumber);
-		assert.is(subject.amount().toString(), "5000000000");
-	});
+	assert.is(subject.recipient(), "lsk72fxrb264kvw6zuojntmzzsqds35sqvfzz76d7");
+});
+
+test("returns transaction amount", () => {
+	assert.instance(subject.amount(), BigNumber);
+	assert.is(subject.amount().toString(), "100000000");
+});
+
+test("returns sum of unlock objects amounts if type is unlockToken", async () => {
+	subject = await createService(SignedTransactionData).configure(
+		transaction.id,
+		{
+			...transaction,
+			moduleID: 5,
+			assetID: 2,
+			asset: {
+				unlockObjects: [
+					{
+						delegateAddress: "lskc579agejjw3fo9nvgg85r8vo6sa5xojtw9qscj",
+						amount: "2000000000",
+						unvoteHeight: 14548930,
+					},
+					{
+						delegateAddress: "8c955e70d0da3e0424abc4c0683280232f41c48b",
+						amount: "3000000000",
+						unvoteHeight: 14548929,
+					},
+				],
+			},
+		},
+		transaction,
+	);
+
+	assert.instance(subject.amount(), BigNumber);
+	assert.is(subject.amount().toString(), "5000000000");
 });
 
 test("#fee", () => {

--- a/packages/lsk/source/transaction.dto.test.js
+++ b/packages/lsk/source/transaction.dto.test.js
@@ -20,46 +20,44 @@ test("#blockId", () => {
 	assert.is(subject.blockId(), "52bb109394008afc59fae3bc288c0c52e4f50ad1e173afb164c7df40d44ff0ec");
 });
 
-describe("#type", () => {
-	test("vote", () => {
-		assert.is(subject.type(), "vote");
-	});
+test("#type - vote", () => {
+	assert.is(subject.type(), "vote");
+});
 
-	test("unvote", async () => {
-		const data = {
-			...Fixture.data[0],
-			asset: {
-				votes: [
-					{
-						delegateAddress: "lskoh8tctdfpdaf8utmtevbd2f9b8vj2tmazeq8e3",
-						amount: "-29163000000000",
-					},
-				],
-			},
-		};
+test("#type - unvote", async () => {
+	const data = {
+		...Fixture.data[0],
+		asset: {
+			votes: [
+				{
+					delegateAddress: "lskoh8tctdfpdaf8utmtevbd2f9b8vj2tmazeq8e3",
+					amount: "-29163000000000",
+				},
+			],
+		},
+	};
 
-		assert.is((await createService(ConfirmedTransactionData).configure(data)).type(), "unvote");
-	});
+	assert.is((await createService(ConfirmedTransactionData).configure(data)).type(), "unvote");
+});
 
-	test("voteCombination", async () => {
-		const data = {
-			...Fixture.data[0],
-			asset: {
-				votes: [
-					{
-						delegateAddress: "lskoh8tctdfpdaf8utmtevbd2f9b8vj2tmazeq8e3",
-						amount: "29163000000000",
-					},
-					{
-						delegateAddress: "lskoh8tctdfpdaf8utmtevbd2f9b8vj2tmazeq8e3",
-						amount: "-29163000000000",
-					},
-				],
-			},
-		};
+test("#type - voteCombination", async () => {
+	const data = {
+		...Fixture.data[0],
+		asset: {
+			votes: [
+				{
+					delegateAddress: "lskoh8tctdfpdaf8utmtevbd2f9b8vj2tmazeq8e3",
+					amount: "29163000000000",
+				},
+				{
+					delegateAddress: "lskoh8tctdfpdaf8utmtevbd2f9b8vj2tmazeq8e3",
+					amount: "-29163000000000",
+				},
+			],
+		},
+	};
 
-		assert.is((await createService(ConfirmedTransactionData).configure(data)).type(), "voteCombination");
-	});
+	assert.is((await createService(ConfirmedTransactionData).configure(data)).type(), "voteCombination");
 });
 
 test("#timestamp", () => {
@@ -84,34 +82,32 @@ test("#recipients", () => {
 	assert.array(subject.recipients());
 });
 
-describe("#amount", () => {
-	test("returns transaction amount", () => {
-		assert.equal(subject.amount(), BigNumber.make("1"));
+test("returns transaction amount", () => {
+	assert.equal(subject.amount(), BigNumber.make("1"));
+});
+
+test("returns sum of unlock objects amounts if type is unlockToken", async () => {
+	subject = await createService(ConfirmedTransactionData).configure({
+		...Fixture.data[0],
+		moduleAssetName: "dpos:unlockToken",
+		asset: {
+			unlockObjects: [
+				{
+					delegateAddress: "lskc579agejjw3fo9nvgg85r8vo6sa5xojtw9qscj",
+					amount: "2000000000",
+					unvoteHeight: 14548930,
+				},
+				{
+					delegateAddress: "8c955e70d0da3e0424abc4c0683280232f41c48b",
+					amount: "3000000000",
+					unvoteHeight: 14548929,
+				},
+			],
+		},
 	});
 
-	test("returns sum of unlock objects amounts if type is unlockToken", async () => {
-		subject = await createService(ConfirmedTransactionData).configure({
-			...Fixture.data[0],
-			moduleAssetName: "dpos:unlockToken",
-			asset: {
-				unlockObjects: [
-					{
-						delegateAddress: "lskc579agejjw3fo9nvgg85r8vo6sa5xojtw9qscj",
-						amount: "2000000000",
-						unvoteHeight: 14548930,
-					},
-					{
-						delegateAddress: "8c955e70d0da3e0424abc4c0683280232f41c48b",
-						amount: "3000000000",
-						unvoteHeight: 14548929,
-					},
-				],
-			},
-		});
-
-		assert.instance(subject.amount(), BigNumber);
-		assert.is(subject.amount().toString(), "5000000000");
-	});
+	assert.instance(subject.amount(), BigNumber);
+	assert.is(subject.amount().toString(), "5000000000");
 });
 
 test("#fee", () => {

--- a/packages/lsk/source/transaction.serializer.test.js
+++ b/packages/lsk/source/transaction.serializer.test.js
@@ -90,7 +90,7 @@ for (const transaction of clone(transactions)) {
 	});
 }
 
-describe("#toHuman", () => {
+describe("#toHuman", ({ afterEach, beforeEach, test }) => {
 	for (const transaction of clone(transactions)) {
 		test("should serialize to human (%s)", async () => {
 			const subject = await createService(TransactionSerializer);
@@ -117,7 +117,7 @@ describe("#toHuman", () => {
 	});
 });
 
-describe("#toString", () => {
+describe("#toString", ({ afterEach, beforeEach, test }) => {
 	for (const transaction of clone(transactions)) {
 		test("should serialize to string (%s)", async () => {
 			const subject = await createService(TransactionSerializer);

--- a/packages/neo/source/ledger.service.test.js
+++ b/packages/neo/source/ledger.service.test.js
@@ -33,7 +33,7 @@ const createMockService = async (record, opts) => {
 	return transport;
 };
 
-describe("disconnect", () => {
+describe("disconnect", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a resolved transport closure", async () => {
 		const subject = await createMockService("");
 
@@ -41,7 +41,7 @@ describe("disconnect", () => {
 	});
 });
 
-describe("disconnect", () => {
+describe("disconnect", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a resolved transport closure", async () => {
 		const subject = await createMockService("");
 
@@ -49,7 +49,7 @@ describe("disconnect", () => {
 	});
 });
 
-describe("getVersion", () => {
+describe("getVersion", ({ afterEach, beforeEach, test }) => {
 	test("should pass with an app version", async () => {
 		const subject = await createMockService(ledger.appVersion.record);
 
@@ -57,7 +57,7 @@ describe("getVersion", () => {
 	});
 });
 
-describe("getPublicKey", () => {
+describe("getPublicKey", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a compressed publicKey", async () => {
 		const subject = await createMockService(ledger.publicKey.record);
 
@@ -65,7 +65,7 @@ describe("getPublicKey", () => {
 	});
 });
 
-describe("signTransaction", () => {
+describe("signTransaction", ({ afterEach, beforeEach, test }) => {
 	test.skip("should pass with a signature", async () => {
 		const subject = await createMockService(ledger.publicKey.record + ledger.transaction.record, {
 			autoSkipUnknownApdu: true,
@@ -86,7 +86,7 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signMessage", () => {
+describe("signMessage", ({ afterEach, beforeEach, test }) => {
 	test("should pass with an ecdsa signature", async () => {
 		const subject = await createMockService("");
 

--- a/packages/profiles/source/contact.test.js
+++ b/packages/profiles/source/contact.test.js
@@ -8,7 +8,7 @@ import { Profile } from "./profile";
 
 test.before(() => bootContainer());
 
-describe("contact", () => {
+describe("contact", ({ afterEach, beforeEach, test }) => {
 	let subject;
 
 	test.before.each(() => {

--- a/packages/profiles/source/delegate.service.test.js
+++ b/packages/profiles/source/delegate.service.test.js
@@ -48,122 +48,118 @@ test.before.each(async () => {
 	});
 });
 
-describe("DelegateService", () => {
-	test("should sync the delegates", async () => {
-		assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
+test("should sync the delegates", async () => {
+	assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
 
-		await subject.sync(profile, "ARK", "ark.devnet");
+	await subject.sync(profile, "ARK", "ark.devnet");
 
-		assert.array(subject.all("ARK", "ark.devnet"));
-		assert.length(subject.all("ARK", "ark.devnet"), 200);
+	assert.array(subject.all("ARK", "ark.devnet"));
+	assert.length(subject.all("ARK", "ark.devnet"), 200);
+});
+
+test("should sync the delegates only one page", async () => {
+	nock.cleanAll();
+	nock(/.+/).get("/api/delegates").reply(200, require("../test/fixtures/client/delegates-single-page.json"));
+
+	assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
+
+	await subject.sync(profile, "ARK", "ark.devnet");
+
+	assert.array(subject.all("ARK", "ark.devnet"));
+	assert.length(subject.all("ARK", "ark.devnet"), 10);
+});
+
+test("should sync the delegates when network does not support FastDelegateSync", async () => {
+	assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
+
+	mockery(profile.coins().set("ARK", "ark.devnet").network(), "meta").mockReturnValue({
+		fastDelegateSync: false,
 	});
 
-	test("should sync the delegates only one page", async () => {
-		nock.cleanAll();
-		nock(/.+/).get("/api/delegates").reply(200, require("../test/fixtures/client/delegates-single-page.json"));
+	await subject.sync(profile, "ARK", "ark.devnet");
 
-		assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
+	assert.array(subject.all("ARK", "ark.devnet"));
+	assert.length(subject.all("ARK", "ark.devnet"), 200);
+});
 
-		await subject.sync(profile, "ARK", "ark.devnet");
+test("should sync the delegates of all coins", async () => {
+	assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
 
-		assert.array(subject.all("ARK", "ark.devnet"));
-		assert.length(subject.all("ARK", "ark.devnet"), 10);
-	});
+	await subject.syncAll(profile);
 
-	test("should sync the delegates when network does not support FastDelegateSync", async () => {
-		assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
+	assert.array(subject.all("ARK", "ark.devnet"));
+	assert.length(subject.all("ARK", "ark.devnet"), 200);
+});
 
-		mockery(profile.coins().set("ARK", "ark.devnet").network(), "meta").mockReturnValue({
-			fastDelegateSync: false,
-		});
+test("#findByAddress", async () => {
+	await subject.syncAll(profile);
+	assert.truthy(subject.findByAddress("ARK", "ark.devnet", "DSyG9hK9CE8eyfddUoEvsga4kNVQLdw2ve"));
+	assert.throws(() => subject.findByAddress("ARK", "ark.devnet", "unknown"), /No delegate for/);
+});
 
-		await subject.sync(profile, "ARK", "ark.devnet");
+test("#findByPublicKey", async () => {
+	await subject.syncAll(profile);
+	assert.truthy(
+		subject.findByPublicKey(
+			"ARK",
+			"ark.devnet",
+			"033a5474f68f92f254691e93c06a2f22efaf7d66b543a53efcece021819653a200",
+		),
+	);
+	assert.throws(() => subject.findByPublicKey("ARK", "ark.devnet", "unknown"), /No delegate for/);
+});
 
-		assert.array(subject.all("ARK", "ark.devnet"));
-		assert.length(subject.all("ARK", "ark.devnet"), 200);
-	});
+test("#findByUsername", async () => {
+	await subject.syncAll(profile);
+	assert.truthy(subject.findByUsername("ARK", "ark.devnet", "alessio"));
+	assert.throws(() => subject.findByUsername("ARK", "ark.devnet", "unknown"), /No delegate for/);
+});
 
-	test("should sync the delegates of all coins", async () => {
-		assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
+test("should return an empty array if there are no public keys", async () => {
+	const mappedDelegates = subject.map(wallet, []);
 
-		await subject.syncAll(profile);
+	assert.array(mappedDelegates);
+	assert.length(mappedDelegates, 0);
+});
 
-		assert.array(subject.all("ARK", "ark.devnet"));
-		assert.length(subject.all("ARK", "ark.devnet"), 200);
-	});
+test("should map the public keys to read-only wallets", async () => {
+	const delegates = require("../test/fixtures/client/delegates-1.json").data;
+	const addresses = delegates.map((delegate) => delegate.address);
+	const publicKeys = delegates.map((delegate) => delegate.publicKey);
+	const usernames = delegates.map((delegate) => delegate.username);
 
-	test("#findByAddress", async () => {
-		await subject.syncAll(profile);
-		assert.truthy(subject.findByAddress("ARK", "ark.devnet", "DSyG9hK9CE8eyfddUoEvsga4kNVQLdw2ve"));
-		assert.throws(() => subject.findByAddress("ARK", "ark.devnet", "unknown"), /No delegate for/);
-	});
+	await subject.sync(profile, wallet.coinId(), wallet.networkId());
 
-	test("#findByPublicKey", async () => {
-		await subject.syncAll(profile);
-		assert.truthy(
-			subject.findByPublicKey(
-				"ARK",
-				"ark.devnet",
-				"033a5474f68f92f254691e93c06a2f22efaf7d66b543a53efcece021819653a200",
-			),
-		);
-		assert.throws(() => subject.findByPublicKey("ARK", "ark.devnet", "unknown"), /No delegate for/);
-	});
+	const mappedDelegates = subject.map(wallet, publicKeys);
 
-	test("#findByUsername", async () => {
-		await subject.syncAll(profile);
-		assert.truthy(subject.findByUsername("ARK", "ark.devnet", "alessio"));
-		assert.throws(() => subject.findByUsername("ARK", "ark.devnet", "unknown"), /No delegate for/);
-	});
+	assert.array(mappedDelegates);
+	assert.length(mappedDelegates, 100);
 
-	describe("#map", () => {
-		test("should return an empty array if there are no public keys", async () => {
-			const mappedDelegates = subject.map(wallet, []);
+	for (let i = 0; i < delegates.length; i++) {
+		assert.is(mappedDelegates[i].address(), addresses[i]);
+		assert.is(mappedDelegates[i].publicKey(), publicKeys[i]);
+		assert.is(mappedDelegates[i].username(), usernames[i]);
+	}
+});
 
-			assert.array(mappedDelegates);
-			assert.length(mappedDelegates, 0);
-		});
+test("should skip public keys for which it does not find a delegate", async () => {
+	const delegates = require("../test/fixtures/client/delegates-1.json").data;
+	const addresses = delegates.map((delegate) => delegate.address);
+	const publicKeys = delegates.map((delegate) => delegate.publicKey);
+	const usernames = delegates.map((delegate) => delegate.username);
 
-		test("should map the public keys to read-only wallets", async () => {
-			const delegates = require("../test/fixtures/client/delegates-1.json").data;
-			const addresses = delegates.map((delegate) => delegate.address);
-			const publicKeys = delegates.map((delegate) => delegate.publicKey);
-			const usernames = delegates.map((delegate) => delegate.username);
+	await subject.sync(profile, wallet.coinId(), wallet.networkId());
 
-			await subject.sync(profile, wallet.coinId(), wallet.networkId());
+	const mappedDelegates = subject.map(wallet, publicKeys.concat(["pubkey"]));
 
-			const mappedDelegates = subject.map(wallet, publicKeys);
+	assert.array(mappedDelegates);
+	assert.length(mappedDelegates, 100);
 
-			assert.array(mappedDelegates);
-			assert.length(mappedDelegates, 100);
-
-			for (let i = 0; i < delegates.length; i++) {
-				assert.is(mappedDelegates[i].address(), addresses[i]);
-				assert.is(mappedDelegates[i].publicKey(), publicKeys[i]);
-				assert.is(mappedDelegates[i].username(), usernames[i]);
-			}
-		});
-
-		test("should skip public keys for which it does not find a delegate", async () => {
-			const delegates = require("../test/fixtures/client/delegates-1.json").data;
-			const addresses = delegates.map((delegate) => delegate.address);
-			const publicKeys = delegates.map((delegate) => delegate.publicKey);
-			const usernames = delegates.map((delegate) => delegate.username);
-
-			await subject.sync(profile, wallet.coinId(), wallet.networkId());
-
-			const mappedDelegates = subject.map(wallet, publicKeys.concat(["pubkey"]));
-
-			assert.array(mappedDelegates);
-			assert.length(mappedDelegates, 100);
-
-			for (let i = 0; i < delegates.length; i++) {
-				assert.is(mappedDelegates[i].address(), addresses[i]);
-				assert.is(mappedDelegates[i].publicKey(), publicKeys[i]);
-				assert.is(mappedDelegates[i].username(), usernames[i]);
-			}
-		});
-	});
+	for (let i = 0; i < delegates.length; i++) {
+		assert.is(mappedDelegates[i].address(), addresses[i]);
+		assert.is(mappedDelegates[i].publicKey(), publicKeys[i]);
+		assert.is(mappedDelegates[i].username(), usernames[i]);
+	}
 });
 
 test.run();

--- a/packages/profiles/source/exchange-rate.service.test.js
+++ b/packages/profiles/source/exchange-rate.service.test.js
@@ -79,90 +79,88 @@ test.after.each(() => {
 
 test.before(() => nock.disableNetConnect());
 
-describe("ExchangeRateService", () => {
-	test("should sync a coin for specific profile with wallets argument", async () => {
-		nock(/.+/)
-			.get("/data/dayAvg")
-			.query(true)
-			.reply(200, { BTC: 0.00005048, ConversionType: { type: "direct", conversionSymbol: "" } })
-			.persist();
+test("should sync a coin for specific profile with wallets argument", async () => {
+	nock(/.+/)
+		.get("/data/dayAvg")
+		.query(true)
+		.reply(200, { BTC: 0.00005048, ConversionType: { type: "direct", conversionSymbol: "" } })
+		.persist();
 
-		await subject.syncAll(profile, "DARK");
+	await subject.syncAll(profile, "DARK");
 
-		assert.is(wallet.convertedBalance(), 0.00005048);
-		const allStorage = await container.get(Identifiers.Storage).all();
-		assert.object(allStorage.EXCHANGE_RATE_SERVICE);
-	});
+	assert.is(wallet.convertedBalance(), 0.00005048);
+	const allStorage = await container.get(Identifiers.Storage).all();
+	assert.object(allStorage.EXCHANGE_RATE_SERVICE);
+});
 
-	test("should sync a coin for specific profile without wallets argument", async () => {
-		nock(/.+/)
-			.get("/data/dayAvg")
-			.query(true)
-			.reply(200, { BTC: 0.00002134, ConversionType: { type: "direct", conversionSymbol: "" } })
-			.persist();
+test("should sync a coin for specific profile without wallets argument", async () => {
+	nock(/.+/)
+		.get("/data/dayAvg")
+		.query(true)
+		.reply(200, { BTC: 0.00002134, ConversionType: { type: "direct", conversionSymbol: "" } })
+		.persist();
 
-		await subject.syncAll(profile, "DARK");
+	await subject.syncAll(profile, "DARK");
 
-		assert.is(wallet.convertedBalance(), 0.00002134);
-	});
+	assert.is(wallet.convertedBalance(), 0.00002134);
+});
 
-	test("should fail to sync a coin for a specific profile if there are no wallets", async () => {
-		profile.wallets().flush();
+test("should fail to sync a coin for a specific profile if there are no wallets", async () => {
+	profile.wallets().flush();
 
-		assert.undefined(wallet.data().get(WalletData.ExchangeCurrency));
+	assert.undefined(wallet.data().get(WalletData.ExchangeCurrency));
 
-		await subject.syncAll(profile, "DARK");
+	await subject.syncAll(profile, "DARK");
 
-		assert.undefined(wallet.data().get(WalletData.ExchangeCurrency));
-	});
+	assert.undefined(wallet.data().get(WalletData.ExchangeCurrency));
+});
 
-	test("should store exchange rates and currency in profile wallets if undefined", async () => {
-		nock(/.+/)
-			.get("/data/dayAvg")
-			.query(true)
-			.reply(200, { BTC: 0.00005048, ConversionType: { type: "direct", conversionSymbol: "" } })
-			.persist();
+test("should store exchange rates and currency in profile wallets if undefined", async () => {
+	nock(/.+/)
+		.get("/data/dayAvg")
+		.query(true)
+		.reply(200, { BTC: 0.00005048, ConversionType: { type: "direct", conversionSymbol: "" } })
+		.persist();
 
-		profile.settings().set(ProfileSetting.MarketProvider, "cryptocompare");
+	profile.settings().set(ProfileSetting.MarketProvider, "cryptocompare");
 
-		await subject.syncAll(profile, "DARK");
-		assert.is(wallet.convertedBalance(), 0.00005048);
-	});
+	await subject.syncAll(profile, "DARK");
+	assert.is(wallet.convertedBalance(), 0.00005048);
+});
 
-	test("should cache historic exchange rates", async () => {
-		nock(/.+/)
-			.get("/data/dayAvg")
-			.query(true)
-			.reply(200, { BTC: 0.00005048, ConversionType: { type: "direct", conversionSymbol: "" } })
-			.persist();
+test("should cache historic exchange rates", async () => {
+	nock(/.+/)
+		.get("/data/dayAvg")
+		.query(true)
+		.reply(200, { BTC: 0.00005048, ConversionType: { type: "direct", conversionSymbol: "" } })
+		.persist();
 
-		profile.settings().set(ProfileSetting.MarketProvider, "cryptocompare");
+	profile.settings().set(ProfileSetting.MarketProvider, "cryptocompare");
 
-		await subject.syncAll(profile, "DARK");
-		assert.is(wallet.convertedBalance(), 0.00005048);
+	await subject.syncAll(profile, "DARK");
+	assert.is(wallet.convertedBalance(), 0.00005048);
 
-		nock(/.+/)
-			.get("/data/dayAvg")
-			.query(true)
-			.reply(200, { BTC: 0.00005555, ConversionType: { type: "direct", conversionSymbol: "" } })
-			.persist();
+	nock(/.+/)
+		.get("/data/dayAvg")
+		.query(true)
+		.reply(200, { BTC: 0.00005555, ConversionType: { type: "direct", conversionSymbol: "" } })
+		.persist();
 
-		await subject.syncAll(profile, "DARK");
-		// The price should be the cached price from previous sync: 0.00005048
-		assert.is(wallet.convertedBalance(), 0.00005048);
-	});
+	await subject.syncAll(profile, "DARK");
+	// The price should be the cached price from previous sync: 0.00005048
+	assert.is(wallet.convertedBalance(), 0.00005048);
+});
 
-	test("handle restore", async () => {
-		await assert.resolves(() => subject.restore());
+test("handle restore", async () => {
+	await assert.resolves(() => subject.restore());
 
-		assert.object(await container.get(Identifiers.Storage).get("EXCHANGE_RATE_SERVICE"));
+	assert.object(await container.get(Identifiers.Storage).get("EXCHANGE_RATE_SERVICE"));
 
-		container.get(Identifiers.Storage).set("EXCHANGE_RATE_SERVICE", null);
-		await assert.resolves(() => subject.restore());
+	container.get(Identifiers.Storage).set("EXCHANGE_RATE_SERVICE", null);
+	await assert.resolves(() => subject.restore());
 
-		container.get(Identifiers.Storage).set("EXCHANGE_RATE_SERVICE", undefined);
-		await assert.resolves(() => subject.restore());
-	});
+	container.get(Identifiers.Storage).set("EXCHANGE_RATE_SERVICE", undefined);
+	await assert.resolves(() => subject.restore());
 });
 
 test.run();

--- a/packages/profiles/source/fee.service.test.js
+++ b/packages/profiles/source/fee.service.test.js
@@ -42,34 +42,32 @@ test.before.each(async () => {
 	subject = new FeeService();
 });
 
-describe("FeeService", () => {
-	test("should sync fees", async () => {
-		assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
+test("should sync fees", async () => {
+	assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
 
-		await subject.sync(profile, "ARK", "ark.devnet");
-		assert.length(Object.keys(subject.all("ARK", "ark.devnet")), 11);
-	});
+	await subject.sync(profile, "ARK", "ark.devnet");
+	assert.length(Object.keys(subject.all("ARK", "ark.devnet")), 11);
+});
 
-	test("should sync fees of all coins", async () => {
-		assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
+test("should sync fees of all coins", async () => {
+	assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
 
-		await subject.syncAll(profile);
+	await subject.syncAll(profile);
 
-		assert.length(Object.keys(subject.all("ARK", "ark.devnet")), 11);
-	});
+	assert.length(Object.keys(subject.all("ARK", "ark.devnet")), 11);
+});
 
-	test("#findByType", async () => {
-		assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
+test("#findByType", async () => {
+	assert.throws(() => subject.all("ARK", "ark.devnet"), "have not been synchronized yet");
 
-		await subject.syncAll(profile);
+	await subject.syncAll(profile);
 
-		const fees = subject.findByType("ARK", "ark.devnet", "transfer");
+	const fees = subject.findByType("ARK", "ark.devnet", "transfer");
 
-		assert.is(fees.min.toHuman(), 0.00357);
-		assert.is(fees.avg.toHuman(), 0.1);
-		assert.is(fees.max.toHuman(), 0.1);
-		assert.is(fees.static.toHuman(), 0.1);
-	});
+	assert.is(fees.min.toHuman(), 0.00357);
+	assert.is(fees.avg.toHuman(), 0.1);
+	assert.is(fees.max.toHuman(), 0.1);
+	assert.is(fees.static.toHuman(), 0.1);
 });
 
 test.run();

--- a/packages/profiles/source/known-wallet.service.test.js
+++ b/packages/profiles/source/known-wallet.service.test.js
@@ -63,28 +63,26 @@ test.before.each(async () => {
 
 test.after.each(() => nock.cleanAll());
 
-describe("KnownWalletService", () => {
-	test("#name", async () => {
-		assert.is(subject.name("ark.devnet", "AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67"), "ACF Hot Wallet");
-		assert.is(subject.name("ark.devnet", "AWkBFnqvCF4jhqPSdE2HBPJiwaf67tgfGR"), "ACF Hot Wallet (old)");
-		assert.is(subject.name("ark.devnet", "AWkBFnqvCF4jhqPSdE2HBPJiwaf67tgfGRa"), undefined);
-	});
+test("#name", async () => {
+	assert.is(subject.name("ark.devnet", "AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67"), "ACF Hot Wallet");
+	assert.is(subject.name("ark.devnet", "AWkBFnqvCF4jhqPSdE2HBPJiwaf67tgfGR"), "ACF Hot Wallet (old)");
+	assert.is(subject.name("ark.devnet", "AWkBFnqvCF4jhqPSdE2HBPJiwaf67tgfGRa"), undefined);
+});
 
-	test("#is", async () => {
-		assert.true(subject.is("ark.devnet", "AFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V"));
-		assert.false(subject.is("ark.devnet", "AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67s"));
-	});
+test("#is", async () => {
+	assert.true(subject.is("ark.devnet", "AFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V"));
+	assert.false(subject.is("ark.devnet", "AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67s"));
+});
 
-	test("#isExchange", async () => {
-		assert.true(subject.isExchange("ark.devnet", "AFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V"));
-		assert.false(subject.isExchange("ark.devnet", "AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67"));
-		assert.false(subject.isExchange("unknown", "AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67"));
-	});
+test("#isExchange", async () => {
+	assert.true(subject.isExchange("ark.devnet", "AFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V"));
+	assert.false(subject.isExchange("ark.devnet", "AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67"));
+	assert.false(subject.isExchange("unknown", "AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67"));
+});
 
-	test("#isTeam", async () => {
-		assert.true(subject.isTeam("ark.devnet", "AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67"));
-		assert.false(subject.isTeam("ark.devnet", "AFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V"));
-	});
+test("#isTeam", async () => {
+	assert.true(subject.isTeam("ark.devnet", "AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67"));
+	assert.false(subject.isTeam("ark.devnet", "AFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V"));
 });
 
 test.run();

--- a/packages/profiles/source/notification.transactions.service.test.js
+++ b/packages/profiles/source/notification.transactions.service.test.js
@@ -21,7 +21,7 @@ let notificationsRepository;
 let subjectTransactionNotificationService;
 let profile;
 
-describe("ProfileTransactionNotificationService", () => {
+describe("ProfileTransactionNotificationService", ({ afterEach, beforeEach, test }) => {
 	test.before(async () => {
 		bootContainer();
 

--- a/packages/profiles/source/password.test.js
+++ b/packages/profiles/source/password.test.js
@@ -6,7 +6,7 @@ import { PasswordManager } from "./password";
 
 test.before(() => bootContainer());
 
-describe("PasswordManager", () => {
+describe("PasswordManager", ({ afterEach, beforeEach, test }) => {
 	test("should set and get password", () => {
 		const subject = new PasswordManager();
 

--- a/packages/profiles/source/plugin-registry.dto.test.js
+++ b/packages/profiles/source/plugin-registry.dto.test.js
@@ -3,8 +3,8 @@ import "reflect-metadata";
 
 import { RegistryPlugin } from "./plugin-registry.dto";
 
-describe("RegistryPlugin", () => {
-	describe("sourceProvider", () => {
+describe("RegistryPlugin", ({ afterEach, beforeEach, test }) => {
+	describe("sourceProvider", ({ afterEach, beforeEach, test }) => {
 		for (const [company, project] of [
 			["company", "project"],
 			["COMPANY", "PROJECT"],
@@ -73,7 +73,7 @@ describe("RegistryPlugin", () => {
 		});
 	});
 
-	describe("getMetadata", () => {
+	describe("getMetadata", ({ afterEach, beforeEach, test }) => {
 		test("should find the requested key", async () => {
 			const subject = new RegistryPlugin(
 				{},

--- a/packages/profiles/source/profile.dumper.test.js
+++ b/packages/profiles/source/profile.dumper.test.js
@@ -39,34 +39,32 @@ test.before.each(() => {
 	subject = new ProfileDumper(profile);
 });
 
-describe("#dump", () => {
-	test("should dump the profile with a password", () => {
-		profile.auth().setPassword("password");
+test("should dump the profile with a password", () => {
+	profile.auth().setPassword("password");
 
-		const { id, password, data } = subject.dump();
+	const { id, password, data } = subject.dump();
 
-		assert.string(id);
-		assert.string(password);
-		assert.string(data);
-	});
+	assert.string(id);
+	assert.string(password);
+	assert.string(data);
+});
 
-	test("should dump the profile without a password", () => {
-		const { id, password, data } = subject.dump();
+test("should dump the profile without a password", () => {
+	const { id, password, data } = subject.dump();
 
-		assert.string(id);
-		assert.undefined(password);
-		assert.string(data);
-	});
+	assert.string(id);
+	assert.undefined(password);
+	assert.string(data);
+});
 
-	test("should fail to dump a profile with a password if the profile was not encrypted", () => {
-		profile = new Profile({ id: "uuid", name: "name", data: "", password: "password" });
-		subject = new ProfileDumper(profile);
+test("should fail to dump a profile with a password if the profile was not encrypted", () => {
+	profile = new Profile({ id: "uuid", name: "name", data: "", password: "password" });
+	subject = new ProfileDumper(profile);
 
-		assert.throws(
-			() => subject.dump(),
-			"The profile [name] has not been encoded or encrypted. Please call [save] before dumping.",
-		);
-	});
+	assert.throws(
+		() => subject.dump(),
+		"The profile [name] has not been encoded or encrypted. Please call [save] before dumping.",
+	);
 });
 
 test.run();

--- a/packages/profiles/source/profile.encrypter.test.js
+++ b/packages/profiles/source/profile.encrypter.test.js
@@ -4,8 +4,8 @@ import "reflect-metadata";
 import { ProfileEncrypter } from "./profile.encrypter";
 import { AttributeBag } from "./helpers/attribute-bag";
 
-// describe("ProfileEncrypter", () => {
-// 	describe("encrypt", () => {
+// describe("ProfileEncrypter", ({ afterEach, beforeEach, test }) => {
+// 	describe("encrypt", ({ afterEach, beforeEach, test }) => {
 // 		test("should work with provided password", () => {
 // 			const auth = mock();
 // 			auth.verifyPassword.calledWith("some-pass").mockReturnValue(true);
@@ -49,7 +49,7 @@ import { AttributeBag } from "./helpers/attribute-bag";
 // 		});
 // 	});
 
-// 	describe("decrypt", () => {
+// 	describe("decrypt", ({ afterEach, beforeEach, test }) => {
 // 		test("should work with provided pasword", () => {
 // 			const attributes = new AttributeBag();
 // 			attributes.set(

--- a/packages/profiles/source/profile.initialiser.test.js
+++ b/packages/profiles/source/profile.initialiser.test.js
@@ -26,7 +26,7 @@ test.before(() => {
 		.persist();
 });
 
-describe("ProfileInitialiser", () => {
+describe("ProfileInitialiser", ({ afterEach, beforeEach, test }) => {
 	let profile;
 
 	test.before.each(() => {

--- a/packages/profiles/source/profile.repository.test.js
+++ b/packages/profiles/source/profile.repository.test.js
@@ -43,310 +43,308 @@ test.before.each(() => {
 	container.constant(Identifiers.ProfileRepository, subject);
 });
 
-describe("ProfileRepository", () => {
-	test("should restore the given profiles", async () => {
-		assert.is(subject.count(), 0);
+test("should restore the given profiles", async () => {
+	assert.is(subject.count(), 0);
 
-		subject.fill({
-			"b999d134-7a24-481e-a95d-bc47c543bfc9": {
-				id: "b999d134-7a24-481e-a95d-bc47c543bfc9",
-				contacts: {
-					"0e147f96-049f-4d89-bad4-ad3341109907": {
-						id: "0e147f96-049f-4d89-bad4-ad3341109907",
-						name: "Jane Doe",
-						starred: false,
-						addresses: [],
+	subject.fill({
+		"b999d134-7a24-481e-a95d-bc47c543bfc9": {
+			id: "b999d134-7a24-481e-a95d-bc47c543bfc9",
+			contacts: {
+				"0e147f96-049f-4d89-bad4-ad3341109907": {
+					id: "0e147f96-049f-4d89-bad4-ad3341109907",
+					name: "Jane Doe",
+					starred: false,
+					addresses: [],
+				},
+			},
+			data: {
+				key: "value",
+			},
+			exchangeTransactions: {},
+			notifications: {
+				"b183aef3-2dba-471a-a588-0fcf8f01b645": {
+					id: "b183aef3-2dba-471a-a588-0fcf8f01b645",
+					icon: "warning",
+					name: "Ledger Update Available",
+					body: "...",
+					action: "Read Changelog",
+				},
+			},
+			plugins: {
+				data: {},
+			},
+			settings: {
+				ADVANCED_MODE: "value",
+				NAME: "John Doe",
+			},
+			wallets: {
+				"ac38fe6d-4b67-4ef1-85be-17c5f6841129": {
+					id: "ac38fe6d-4b67-4ef1-85be-17c5f6841129",
+					coin: "ARK",
+					network: "ark.devnet",
+					address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+					publicKey: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
+					data: {
+						BALANCE: {},
+						SEQUENCE: {},
+					},
+					settings: {
+						ALIAS: "Johnathan Doe",
+						AVATAR: "...",
 					},
 				},
-				data: {
-					key: "value",
-				},
-				exchangeTransactions: {},
-				notifications: {
-					"b183aef3-2dba-471a-a588-0fcf8f01b645": {
-						id: "b183aef3-2dba-471a-a588-0fcf8f01b645",
-						icon: "warning",
-						name: "Ledger Update Available",
-						body: "...",
-						action: "Read Changelog",
+				"0e147f96-049f-4d89-bad4-ad3341109907": {
+					id: "0e147f96-049f-4d89-bad4-ad3341109907",
+					coin: "ARK",
+					network: "ark.devnet",
+					address: "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9",
+					publicKey: "03bbfb43ecb5a54a1e227bb37b5812b5321213838d376e2b455b6af78442621dec",
+					data: {
+						BALANCE: {},
+						SEQUENCE: {},
 					},
-				},
-				plugins: {
-					data: {},
-				},
-				settings: {
-					ADVANCED_MODE: "value",
-					NAME: "John Doe",
-				},
-				wallets: {
-					"ac38fe6d-4b67-4ef1-85be-17c5f6841129": {
-						id: "ac38fe6d-4b67-4ef1-85be-17c5f6841129",
-						coin: "ARK",
-						network: "ark.devnet",
-						address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-						publicKey: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
-						data: {
-							BALANCE: {},
-							SEQUENCE: {},
-						},
-						settings: {
-							ALIAS: "Johnathan Doe",
-							AVATAR: "...",
-						},
-					},
-					"0e147f96-049f-4d89-bad4-ad3341109907": {
-						id: "0e147f96-049f-4d89-bad4-ad3341109907",
-						coin: "ARK",
-						network: "ark.devnet",
-						address: "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9",
-						publicKey: "03bbfb43ecb5a54a1e227bb37b5812b5321213838d376e2b455b6af78442621dec",
-						data: {
-							BALANCE: {},
-							SEQUENCE: {},
-						},
-						settings: {
-							ALIAS: "Jane Doe",
-							AVATAR: "...",
-						},
+					settings: {
+						ALIAS: "Jane Doe",
+						AVATAR: "...",
 					},
 				},
 			},
-		});
-
-		assert.is(subject.count(), 1);
+		},
 	});
 
-	test("should push, get, list and forget any given profiles", async () => {
-		assert.is(subject.count(), 0);
+	assert.is(subject.count(), 1);
+});
 
-		const john = subject.create("John");
+test("should push, get, list and forget any given profiles", async () => {
+	assert.is(subject.count(), 0);
 
-		assert.is(subject.count(), 1);
-		assert.instance(subject.findById(john.id()), Profile);
+	const john = subject.create("John");
 
-		const jane = subject.create("Jane");
+	assert.is(subject.count(), 1);
+	assert.instance(subject.findById(john.id()), Profile);
 
-		assert.is(subject.count(), 2);
-		assert.instance(subject.findById(jane.id()), Profile);
-		assert.instance(subject.findByName(jane.name()), Profile);
-		assert.true(subject.has(jane.id()));
+	const jane = subject.create("Jane");
 
-		subject.forget(jane.id());
+	assert.is(subject.count(), 2);
+	assert.instance(subject.findById(jane.id()), Profile);
+	assert.instance(subject.findByName(jane.name()), Profile);
+	assert.true(subject.has(jane.id()));
 
-		assert.is(subject.count(), 1);
-		assert.false(subject.has(jane.id()));
-		assert.throws(() => subject.findById(jane.id()), "No profile found for");
+	subject.forget(jane.id());
+
+	assert.is(subject.count(), 1);
+	assert.false(subject.has(jane.id()));
+	assert.throws(() => subject.findById(jane.id()), "No profile found for");
+});
+
+test("should get all profiles", async () => {
+	subject.create("John");
+	subject.create("Jane");
+
+	assert.length(Object.keys(subject.all()), 2);
+});
+
+test("should get all keys", async () => {
+	subject.create("John");
+	subject.create("Jane");
+
+	assert.length(subject.keys(), 2);
+});
+
+test("should get all values", async () => {
+	subject.create("John");
+	subject.create("Jane");
+
+	assert.length(subject.values(), 2);
+});
+
+test("should forget all values", async () => {
+	subject.create("Jane");
+
+	assert.length(subject.values(), 1);
+
+	subject.flush();
+
+	assert.length(subject.values(), 0);
+});
+
+test("should get the first and last profile", async () => {
+	const john = subject.create("John");
+	const jane = subject.create("Jane");
+
+	assert.is(subject.first(), john);
+	assert.is(subject.last(), jane);
+});
+
+test("should fail to push a profile with a duplicate name", async () => {
+	subject.create("John");
+
+	assert.throws(() => subject.create("John"), "The profile [John] already exists.");
+});
+
+test("should fail to forget a profile that doesn't exist", async () => {
+	assert.throws(() => subject.forget("doesnotexist"), "No profile found for");
+});
+
+test("should dump profiles without a password", async () => {
+	const john = subject.create("John");
+
+	await importByMnemonic(john, identity.mnemonic, "ARK", "ark.devnet");
+
+	subject.persist(john);
+
+	const repositoryDump = subject.toObject();
+
+	const restoredJohn = new Profile(repositoryDump[john.id()]);
+	await new ProfileImporter(restoredJohn).import();
+	await restoredJohn.sync();
+
+	assert.equal(new ProfileSerialiser(restoredJohn).toJSON(), new ProfileSerialiser(john).toJSON());
+});
+
+test("should dump profiles with a password", async () => {
+	const jane = subject.create("Jane");
+
+	await importByMnemonic(jane, identity.mnemonic, "ARK", "ark.devnet");
+
+	jane.password().set("password");
+	jane.auth().setPassword("password");
+
+	subject.persist(jane);
+
+	const repositoryDump = subject.toObject();
+
+	const restoredJane = new Profile(repositoryDump[jane.id()]);
+	await new ProfileImporter(restoredJane).import("password");
+	await restoredJane.sync();
+
+	assert.equal(new ProfileSerialiser(restoredJane).toJSON(), new ProfileSerialiser(jane).toJSON());
+});
+
+test("should export ok", async () => {
+	const profile = subject.create("John");
+	await importByMnemonic(profile, identity.mnemonic, "ARK", "ark.devnet");
+
+	const exported = subject.export(profile, {
+		excludeEmptyWallets: false,
+		excludeLedgerWallets: false,
+		addNetworkInformation: true,
+		saveGeneralSettings: true,
 	});
 
-	test("should get all profiles", async () => {
-		subject.create("John");
-		subject.create("Jane");
+	assert.string(exported);
+});
 
-		assert.length(Object.keys(subject.all()), 2);
-	});
+test("should export ok with password", async () => {
+	const profile = subject.create("John");
+	profile.auth().setPassword("some pass");
+	await importByMnemonic(profile, identity.mnemonic, "ARK", "ark.devnet");
 
-	test("should get all keys", async () => {
-		subject.create("John");
-		subject.create("Jane");
-
-		assert.length(subject.keys(), 2);
-	});
-
-	test("should get all values", async () => {
-		subject.create("John");
-		subject.create("Jane");
-
-		assert.length(subject.values(), 2);
-	});
-
-	test("should forget all values", async () => {
-		subject.create("Jane");
-
-		assert.length(subject.values(), 1);
-
-		subject.flush();
-
-		assert.length(subject.values(), 0);
-	});
-
-	test("should get the first and last profile", async () => {
-		const john = subject.create("John");
-		const jane = subject.create("Jane");
-
-		assert.is(subject.first(), john);
-		assert.is(subject.last(), jane);
-	});
-
-	test("should fail to push a profile with a duplicate name", async () => {
-		subject.create("John");
-
-		assert.throws(() => subject.create("John"), "The profile [John] already exists.");
-	});
-
-	test("should fail to forget a profile that doesn't exist", async () => {
-		assert.throws(() => subject.forget("doesnotexist"), "No profile found for");
-	});
-
-	test("should dump profiles without a password", async () => {
-		const john = subject.create("John");
-
-		await importByMnemonic(john, identity.mnemonic, "ARK", "ark.devnet");
-
-		subject.persist(john);
-
-		const repositoryDump = subject.toObject();
-
-		const restoredJohn = new Profile(repositoryDump[john.id()]);
-		await new ProfileImporter(restoredJohn).import();
-		await restoredJohn.sync();
-
-		assert.equal(new ProfileSerialiser(restoredJohn).toJSON(), new ProfileSerialiser(john).toJSON());
-	});
-
-	test("should dump profiles with a password", async () => {
-		const jane = subject.create("Jane");
-
-		await importByMnemonic(jane, identity.mnemonic, "ARK", "ark.devnet");
-
-		jane.password().set("password");
-		jane.auth().setPassword("password");
-
-		subject.persist(jane);
-
-		const repositoryDump = subject.toObject();
-
-		const restoredJane = new Profile(repositoryDump[jane.id()]);
-		await new ProfileImporter(restoredJane).import("password");
-		await restoredJane.sync();
-
-		assert.equal(new ProfileSerialiser(restoredJane).toJSON(), new ProfileSerialiser(jane).toJSON());
-	});
-
-	test("should export ok", async () => {
-		const profile = subject.create("John");
-		await importByMnemonic(profile, identity.mnemonic, "ARK", "ark.devnet");
-
-		const exported = subject.export(profile, {
+	const exported = subject.export(
+		profile,
+		{
 			excludeEmptyWallets: false,
 			excludeLedgerWallets: false,
 			addNetworkInformation: true,
 			saveGeneralSettings: true,
-		});
+		},
+		"some pass",
+	);
 
-		assert.string(exported);
+	assert.string(exported);
+});
+
+test("should import ok", async () => {
+	const data =
+		"eyJpZCI6Ijc5YzViNWE1LTdlM2QtNDhlNC1hNjkwLWM2OTA5MzA1NDA0OSIsImNvbnRhY3RzIjp7fSwiZGF0YSI6e30sImV4Y2hhbmdlVHJhbnNhY3Rpb25zIjp7fSwibm90aWZpY2F0aW9ucyI6e30sInBlZXJzIjp7fSwicGx1Z2lucyI6e30sInNldHRpbmdzIjp7IkFDQ0VOVF9DT0xPUiI6ImdyZWVuIiwiQURWQU5DRURfTU9ERSI6ZmFsc2UsIkFVVE9NQVRJQ19TSUdOX09VVF9QRVJJT0QiOjE1LCJCSVAzOV9MT0NBTEUiOiJlbmdsaXNoIiwiREFTSEJPQVJEX1RSQU5TQUNUSU9OX0hJU1RPUlkiOmZhbHNlLCJET19OT1RfU0hPV19GRUVfV0FSTklORyI6ZmFsc2UsIkVSUk9SX1JFUE9SVElORyI6ZmFsc2UsIkVYQ0hBTkdFX0NVUlJFTkNZIjoiQlRDIiwiTE9DQUxFIjoiZW4tVVMiLCJNQVJLRVRfUFJPVklERVIiOiJjcnlwdG9jb21wYXJlIiwiTkFNRSI6IkpvaG4iLCJTQ1JFRU5TSE9UX1BST1RFQ1RJT04iOnRydWUsIlRIRU1FIjoibGlnaHQiLCJUSU1FX0ZPUk1BVCI6Img6bW0gQSIsIlVTRV9URVNUX05FVFdPUktTIjpmYWxzZX0sIndhbGxldHMiOnsiMjRjMTExNDctMGU3ZC00NmEwLWFjNzEtMjRlZGE4YzFmNGJmIjp7ImlkIjoiMjRjMTExNDctMGU3ZC00NmEwLWFjNzEtMjRlZGE4YzFmNGJmIiwiZGF0YSI6eyJDT0lOIjoiQVJLIiwiTkVUV09SSyI6ImFyay5kZXZuZXQiLCJBRERSRVNTIjoiRDYxbWZTZ2d6YnZRZ1RVZTZKaFlLSDJkb0hhcUozRHlpYiIsIlBVQkxJQ19LRVkiOiIwMzQxNTFhM2VjNDZiNTY3MGE2ODJiMGE2MzM5NGY4NjM1ODdkMWJjOTc0ODNiMWI2YzcwZWI1OGU3ZjBhZWQxOTIiLCJCQUxBTkNFIjp7ImF2YWlsYWJsZSI6IjU1ODI3MDkzNDQ0NTU2IiwiZmVlcyI6IjU1ODI3MDkzNDQ0NTU2In0sIkJST0FEQ0FTVEVEX1RSQU5TQUNUSU9OUyI6e30sIkRFUklWQVRJT05fVFlQRSI6ImJpcDM5IiwiSU1QT1JUX01FVEhPRCI6IkJJUDM5Lk1ORU1PTklDIiwiU0VRVUVOQ0UiOiIxMTE5MzIiLCJTSUdORURfVFJBTlNBQ1RJT05TIjp7fSwiVk9URVMiOltdLCJWT1RFU19BVkFJTEFCTEUiOjAsIlZPVEVTX1VTRUQiOjAsIldBSVRJTkdfRk9SX09VUl9TSUdOQVRVUkVfVFJBTlNBQ1RJT05TIjp7fSwiV0FJVElOR19GT1JfT1RIRVJfU0lHTkFUVVJFU19UUkFOU0FDVElPTlMiOnt9LCJTVEFSUkVEIjpmYWxzZX0sInNldHRpbmdzIjp7IkFWQVRBUiI6IjxzdmcgdmVyc2lvbj1cIjEuMVwiIHhtbG5zPVwiaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmdcIiBjbGFzcz1cInBpY2Fzc29cIiB3aWR0aD1cIjEwMFwiIGhlaWdodD1cIjEwMFwiIHZpZXdCb3g9XCIwIDAgMTAwIDEwMFwiPjxzdHlsZT4ucGljYXNzbyBjaXJjbGV7bWl4LWJsZW5kLW1vZGU6c29mdC1saWdodDt9PC9zdHlsZT48cmVjdCBmaWxsPVwicmdiKDIzMywgMzAsIDk5KVwiIHdpZHRoPVwiMTAwXCIgaGVpZ2h0PVwiMTAwXCIvPjxjaXJjbGUgcj1cIjUwXCIgY3g9XCI2MFwiIGN5PVwiNDBcIiBmaWxsPVwicmdiKDEzOSwgMTk1LCA3NClcIi8+PGNpcmNsZSByPVwiNDVcIiBjeD1cIjBcIiBjeT1cIjMwXCIgZmlsbD1cInJnYigwLCAxODgsIDIxMilcIi8+PGNpcmNsZSByPVwiNDBcIiBjeD1cIjkwXCIgY3k9XCI1MFwiIGZpbGw9XCJyZ2IoMjU1LCAxOTMsIDcpXCIvPjwvc3ZnPiJ9fX19";
+	assert.instance(await subject.import(data), Profile);
+});
+
+test("should import ok with password", async () => {
+	const data =
+		"ZGU2YTQ3YjQ0NzZkMzZmODEyMzlkMjM0Mzg1Zjc1M2U6NGU3NDYzNjQ3MDRhNDczMDQ1NmQ1MzRhNGMzODRjNDE3NDRkNTk1MjczNDIzMzc0Mzc0YjYxNDQ0YTQ4NjEzOTJiMzM1MzY2MzY0MzQ1NTI3OTJmNTk2YTM4NDczNTU1Mzk1YTc1NTMzNjQ2MzEzNjY0NDE0NDc3NzM2YTcxNzA0NjUyNzc3NTRkNTA2Yjc3Njg1MjUyNzY1YTYzN2E2ODZkNjM1NTMxNjc1NzU0NGUzMjdhNDk3NTc2NjUzNDY2NGIzNDU5MzA1ODc1MzMzOTczNzQ2ODM4NmI1NTUyNmQ0MTMzNDU1MzQyNzY3MDcwMzk3YTU2MzQ2YzRmNTI2Nzc3Mzc0ZTcxNjk1NzQ1Mzc2ZTc5NGI3NTcwNmU3YTM5MzU3MjM5MzM3NjRjNzY0OTM5MmI3NTRmNTc3NjZlNTY3MjczNzU2ZTQ1NmE2OTM3NTI0ZDM2NDE3ODQ3MzQ0ZTczNGU2ZjQ4MzM0Njc1NjU2OTRjNTU3NDdhNDM2MjZhMmY1MDQzNTI2NDQxNjU2NTQ0NDI2ZjY3NjQ1NjYyNDU3MTYxNTk2NjRmNTYzMTM0NjkzMDU2NTA2OTJiMzc2MTc3NjQ2NjZlMmI0YTc4MmI2ODQ5MzAyZjY5Mzc2MjQ2MmY0ZTRhNjg2MTYyNzIzMjUxNTU1MDczNDQ2Mzc4MzU3ODRjNzAzMDYyNWE1NzMyNmI1ODMxNzk3NDM0NjM0ZTUyMzk0NjQ1NGIzMzQ4NjE0NjczNjY0YTRlNzA0NDRkNzU3OTQ4Njc2NDM3NTM2NDMwNjkyYjJiMzI1MTQ4NmUzNzcxNjUzMjRhNjQ3OTUxNGU2NzZkMzc1NjRiMzg3MDMyMzc0Zjc3NTE3OTMzNzc0ZjRhNGQzMDc2Nzc0NjYyMmY0ZTQ5NGE1OTU1Mzk0OTc4NzU3Mjc0NmE2OTU4NGQ1NDcwNTIzNzQ1NmE1NjM3NWE2YTRmNjg2OTRiNjY2ODM2Njg1YTY1NzI1MzRmNzkzMjQ1NTE2NTRmMzQ0ODY2NjE2ZjVhMzYyZjczMmI0ZTU2NDkzNjU1NzY3MDM4NDE2YTRhNmM0ZDc2NDU0MjVhNzEyZjY1NGY3NjQ0NjkzMjRjMmI3OTUxNzQzMDYxNDI2ZjY4MzQ0ZDc4NjkzMjQ0NjM0ZjMzNjk3NjY0NDc1MDZkNmY0MTRjNmQ3NTY5NzU2ZTdhNmE1NDRmNGY0YzQ3NjI1ODMxNDIzNTQ4NmQ2YjM4NzA3YTc0NTU0ODYyNDUzOTRiNzg1NTQ3NjI3NzRlNDg0MjU2MzU2OTZiNjg3NDUzMzkzMTM2NmU2ZDRhMzk0MTc0NzU0MjQ3NmMzNjUyNTc1MjM4NGE2NjQzNzA0NTM1MzczNTQxNDg0ZDYxNzI0ODM1NWE0YTRiNDE0NDZlNjY2NDRkNGQ3MTUxNmM3MjcwNGM2YzRhNjU1MjQ4Mzg3YTZiNmI1MTU2Mzc2YzU2NTU3ODVhNjM3NDJiNmQ1MjM2NTI1MDY2NGQyYjUzNTkzNDM1NmI2YTYxNzY2MjQ4NzQzNTQ3NDE2ZjU3NjU2NzM2NTE0OTQzNjMzNDc0NDI1MDRiMmY0ZDYxNDU1YTQyNmQ2MzQyNjU1NDU3NzA0NzRkNjc1NjZkNTc0Njc0NGEzOTM1NzQ0NzVhNzY2ZDVhNGQ3NDUyNWE0ZjQyNTQ2NzU3NDI3MjM0NmU1ODYzMzMzMDU4NDg3NTUxNGY1MTZlNDM2ZjRhNmEyYjcyNzY0YTc4NTI3NTRmNmM2ZDRhNGI2MzM2NDU0MzM4MzU1MTM2NjE3NDdhMzE3YTQzNmE0NzY0NzU1NjQxNDYzODU4MmI2NTJiNDUzNzM5Njg2OTQzNmEzNjU1NDI0MzUxMzY2ZTc3NzI0MTMxNjc3MDU4NTg2YjMzNTY1MTU2NzI0NjRiNzc2ODY4NTM3MzMyNDY2MTQ3NDE0ODRkMmI2NDM0NDEzNDMwNGI0MzQ0NmY0MTU4NmEyZjQ2NzM3MjY1NzE3MDUzNGQ1NTdhNmI1Njc4NmM0ODc5NzgzNzY2NTE0NTZhNTM2YTRlMzA0YTQ1NmM2MTQ2NGI2OTRhMzQyZjZlNmQ0NDc3NTI1NDRkNGI1NjQzNGQzMDMzNTk2NDQ3NTI3OTQ0MzU0ZDU3NDQ2MzMzNGIzOTZlMzI2NzU4NGY2OTRmMzUzMjU2NzY3MTZkMmY2YTJmNDg0NDMyNzM0ZDU1NGQyYjY0NTA1YTZlNDU0YjU0NzE3OTRiNDQ3MTQ4NTQ2NjZjNDUzODM4MzE0MTRhMzA3ODY0Nzg0YjMxNmQ0NDc0NGQ1MDY5NzM1NjZkNTg3MzRhMzg3ODY1NjY0MjcwNjQyYjUyNmY0NzU0NjE3OTQzN2E2YzU4Mzg2NTU3NWE2OTUyNTc0OTQzNDc3MDM3NGY1NDY0Nzg0ODM1NTU3OTQxNzI2NDUxNjk2MjZhNmQzNzZlNzA0NzQ5MzM3YTc5MzU0YzY2NzMzMDY5NTA2NzYxMzQ0YjY5NTUzMTU4NjI2OTM3NDQ2YzQ2NzM2Njc5Nzc3YTUyNGE2ZDMxNmI1YTM5NzA0ODQ0NmM1MTQxNWE3OTRlNTA3YTM4NTg1Mzc5NGY0NjZiNmI2ZTZjNjIzODU1NTk1MDQyNjY1NDMwNTY0MzQxNzc2ZjRjNDUzNDRmMzg0NTJmNTY2MzQ2NGQzNjVhNDM2YjZmMzEzMTM5NzgzNjMzNzU3MDY1NDIzMTU3NjIzOTc0NDY3MzYzNmIzNjMxNmY2NTM1NTg3YTY2NTY2NjY0NDYzODYxMzg1MDZiNGI3MDQxNDU2NzMwNjc3MDMwMzgyZjZiN2E2MjcxMmY0OTU0NzUzMzQ0NjU0NzZmNTU1NzM0NWE1ODRjNzYzNjZlNTI0ODQ4NGI0ZDU1NzU1MjZiMzc2ZDUyNDg2ODQ5NTE2ODQ1Mzc1NjQ4NzE1MDQ3NzgzOTM5NmE1YTQ5NWE1MzMxNGI1NTY0NjQ1MTY1NzU0NzM1NzI3NDcyNTA2OTM3NzY1NDUxNDM1NTQ5NDM0ZjY1NzA3MjRlMzQ0MTU4MzY0Yzc0Nzg1NzM0Nzk3MTJmNDIzNDc0NDk2YTQxNTI2NTZhNTQ2ZTUzNzA3OTJmNGY1YTU4NTM2ODQ0MzE1MDM4NGY1MjQ1NzAzMDMzNjU1NTJmNzc0NTQ0NmU0YTMyNDI3OTQ3NDE1NDRhNzIzMDUyNzc2MzU5NmQ2YzRlNmQ2NzMxMzQ2ZTRmNjU2MTM3NzQzNzZkNDcyYjQ0NTU0MjUzMzc3OTMzNTg1MjMyNTk2ZTZjNGY3NzU5NmE0YTY1NTI0NjUyMmI0ZDcxNGMzMzUxNmQ2MTYxNDU1NTU4NjM2Yzc2NTY0YzY5NzEzNzU2NTI2ZDRkNTYzNzU4Nzg0ZjU4NTY0MTZkNDY0ZjRkNTc1MDJiMzk3NjY0MzA3OTcwNjM3OTZjMzc3NTY0Mzc2OTMxNjc2ZjVhNDM2NjZkNmM1MTc4NjY3MTU2NDQ2NjU4NDQ3NjQyNTY1MjU3MzU0NjYxMzU0ZTVhNDI2Zjc1NTA3ODM3NjY1MTY3NjgzNjU3MzI2MzJmNmM1YTc5NTg0NTZlMzk0ZjY0NzU3ODRlNjI0OTU2NzM0YTM5NzkyZjRlNDk0ZDU5NGI2YjZmNDY1MjUxMmI3MTMxNDg3MTRlNzE0MjRmNmQ0YTdhMzg2NTM5Mzk3NTZhNDQ3NTQ2NTc1OTMzNWE0NDU4NDE1MzQzMzY0YzYzNDk0YjM1NGM3YTc5NGQ3MzM4NDc2NDQ0NTkzNzc2NmI2ZTc5Mzk2NDY3MzUyYjMyNTE0NTVhNzA0NzQ0Nzk1NTMwMzM3NzRiNmI3ODRkMzE2ZjZjMzQ0ODYxNDEzMzUwNmI2MzQ3NTk3OTQzNTE2YTU2NWE1NTQ5NGEzODRiMzI0YTU4NDg3MTcwMzI0YTU1NDU2YzZlNjg3MzQxNjc3MDUzMzk1MjZhNDU0OTczNmU2NDU1NzA1OTZmNjUzOTU5NDI0MTQxNDIzNjY4Mzc3MjUyNGQ3ODU0Mzg2MjM5NjUzMTU1Njg3MzMyNWEzNzZhNDE0ODJiNTA2NjZkNTI3MDYxNDU3NzMzNzM3MDQ1NmY0ZjYxNTc1NTZlNTc1NzQyNDc2YTczNTA0MzQ3NzU0ZjMyNzE1ODMwMzY0ZDRjNDQ3MTRlNmE2NTRmMzk2YzM5NWEzNzY3NDQ0NDcxNjg3ODRjNmQ3NjVhNDQ2MTRhNjY1NjcyNjQ1NzMxNmQzNjMzMmYzODY2NjUyZjM0NGI2YTRhNzY3MjY1NzczODcyNGE2YzQ5Mzc1MjMyNGU0OTZmNTU3NDQyNDI0NTY1NDk1OTY1NGU2ZTZjNjU1YTZlMmY1NzZkNjY3MDQ3NTc2MTZkNGQyZjU1NjU1MzU1NjgzNzQ2NWE0NzM4NDE1NzRlNDE2NzQ3NDE0ZTc3NzMzMTM3NGI2ZjYyNDU2NTc3NTc1ODU0NDMzNzQ1Njk2NDc4Mzc1OTU2MmI3MTZiNGY2OTVhMzM0MzU5NTI3NjY2NjY2ZDc3MzY0YTRlMzg0NDVhMmIzMDU5NTQ0MzcyNmMzODMyNDc1OTMxNmI1MjQ0NzczODQ3NjY1NDY4NjQ2OTUyMzMzNjcxNmU0ODcyNzg2YjM0NDEzMTU3NTg2NTQ4NDk3YTQ1NmQzNjZlNzQ0YTRhNjYyYjM4NmY2MTQ2MzAzMTZlNmE2YjRkNDQ2MzMwNzE1YTY3NGE0MjczNTk1OTU0NDY1MjUxNGUzMzUyNDM2Nzc1NzA1Mjc0NzU2OTJmMzM0ZjZkNzc1MTU1NmI3MzVhNGEzMzU3NGM1MjcyNDc1MjZhNzA3OTM5NDg0NTQzN2E1MzUxNWE2NTc3MzIzOTY3NTQzNjRjNTQ0NTczMzI0MzY0MzE0ZTUyMmI3ODRmNTA2OTcyMzQ1ODM1MzQ1MzM4NTY3MTRmMzI2ODMyNGM1MTZhNTczODZmNjIzNTcxNjYyZjc0NmUzOTdhMzU0ZTcyNTIzNzYyMzI2MzU2NTg0Nzc1Mzc0ZTMwNjk3NjcwMmI1MTc0MzI3MzY4NDM2ZjVhMzgzNjY0MmY2YjY0NjIzMDQ0MzE3MzQ4NDg3MDZjNDE1OTUwNjk0ZDU3NDk1MzM4NDQ2Njc1NGY0ZjY4NjkzMDQ1MzE2OTM0MmI3NzY5NmM1MjY1NzM2Zjc0Mzk1MDQ1MzczODM0MzU3OTU2NmM0YjRiNTI3MjYzMmIzODQyMzQ2NTcxNmQ0MjcyMzY2YjM3NTY0ODRhNTM0MjU2NTk3MDQ1NGU2NzY1NzY3NzY4MmI3ODc3NDI2YzJmNmQ3YTYxNWEyZjRhNGY0NjU0MzI1YTVhNmE3NzY5NTQ2YTRiNTA2NDUwNTU3MDY1NmM2NjZiMmY0MjY3Nzg2ZDRkNDE3MzM0MzI3NDRiNWE3Nzc4NTQ1YTUwMzE2MzU3NTY2MTZiMzE1MDQ5Njk0Mjc0NjQ3MzczNTYzMDU0NGIzMTZlNTA0NDM4NDE0ZjY4NzEzMTQyNmQzMzZlMzY2NTc1NWE0NjQ2NmMyYjUyNTU0MzQ0Nzg1MjYxNmQ3MzZlNGM3NzM1MzE2YTZhNzM0YzQ1NTA3MTc1NmQ1NDZiNGQzNzVhNTc0ZDcxNDY3MzM2NDc2ZjcwMmY0YzY5NDU2MzcwNmY0MTM4NDQzNjQ0NDc0NTQ2NzY2MzYzNjIzNjM1N2EzNzcwNmI3MjYxNDYzNDUyNmQzNDUzNjM2ODZhNjE0YjZkNzM2MzQ4NTE2ZTQxNjI2MzYxNTAzNTc5MzMyYjc1NzE1NTUxNjM0ZDQ5NGE3MTQ4NmUzMzZhNTk1NTM3NjgzMjcxNGQ0NTUyNjc2MTY0NTY2NzJmNWEzNzY3NDY1MzcyNzE0NjRmNjU2NjU1Nzk3ODMzMmY0ZTQyNjg2ZDY3NGI1NTZlNzE0YjMyNjI1NDdhNTQ1NDMzNjU2ZTZmNzE0YTY5NmE0ZTYzNjIyYjM3NzM1NDMxNGM0NDM2Nzc3NjQ3NTU1OTRjNmIzMzQ1NjM1OTUxNDY1NTc1MzI1MzQ2NGE0YTY3Mzg3NDZkNjU0ZTVhNTA1ODU5NDQ3OTZmNzk3NDczMmI3NjM4NTU0NzU1NDk1ODU2NDY1MzcxNzM1NTZiNDg2YTZmNzM2NzUzNTU0MzUzNGEzNTUzMzI0NTc1NTUyZjYyNGY0OTUwNzI3MjQ2NWEyYjM4NTE3MjY4NWEzNjQ2NzE1YTc0NjY0YTM1NDg1MTU3NjI2ZDRlNjk2NDZmNjc2NTQ5NTA0NjY1Njk3NzM3NTE3ODJmMzM0ZDcxMzI3MDY4NDM0OTU1Nzg1NDYxMzM0MjY5NjI1OTU3Nzk0MjQyNmI2NzQyMzk1MjUyNWE3NDRhNzU2NDcxNzg2ZjU0MmI0NDM0Njc1NTU4NDYzNzY5Mzk2MTc2MmI0NjdhNTg3NzM4NjczNDcyNGI0YzZkNDUzMjZhNTA0YjU0NDY1NjU4NTYzODYyNjUzNzY1NTk3OTc3NjY2Yzc1NjM0NjM1NTkzMDcwNjQ2YTVhNjU2NjQ4NjM2NjUyMzk1MjM1NjQzNjY0NmI2ODUwNTU0NTczN2E0NzRlNzE1NDRiNjU1MTdhNzU2YTUwNDMzMzMyNjg0ZDc0Njg3MjM4NTY0YzM2MzI2OTMyNjk0ZjRmMzU0NTc0NzU2YTU5Njk0ZDU4NzU1MTRiNjM2NzY2NTkzMTRmNDQ3OTM5NDE2ODJiNjE0MzcxMzMzMzZjNDE1NjQxNzk0YzRhNzk0YTRmNGE0OTQyNzc2NzJmNTI2ZTM1Nzk0ZTRjNmMzMjJiNGE2YjY3NTEzMDZmNDE1MjYyNGM0NzU3NTI0YjY3NzY1MTQxNDc3MDYyNTI0ODU2NGUzMzMyNjU3MTU1NzQ3MTJiNzM3OTJmNGU3OTU1NTgzODU0NGIzNTcyNTg1NTUyNGYzMzUwNzE1OTM1NDk2YTQ2NmM2ZjcyNjY3NzM4NDI1MjcwNDk2YjUwNTgzMzMwNTQ0MTYxNDU2OTQ3NGM3MzU4NGI1MDc1NTg2NzQyNTQzNzMzNzc3NTc2NTE2YTQ0Nzc2ZjY1MzY3ODRjMzg0ODQ1NGI0MTZiMmI3NTRkNTk2NzYzNTE2MzU0MzA1OTcwNjg2OTMwNGEzODc2NzkzNjc5NjE0NDQ4N2E0Mjc4Mzk3MjcyNTE0NzcxNmQ1MTY0MzYzNTQ0MmI0NDZjNDQ0NDUzNzk2Yzc1NTIzNDc4NGI2MjYyNDI0ODZhMzg0YTVhNzU1MDQ0NDY2NzY5NmIyYjMwNTY2Njc5NjY1NzU0Nzc0NjUzNzc3OTJmNjQ1ODJmMmY1NTc1MmY1ODU2Mzk3NjQzNGU0Nzc5NGIzNzRkNjg3NjY1NjQzNDQ0MmY0MjRiMzY2ODM0Mzg0NjczNGQyYjUxNDg2NjM4NzE1NjY2NTUyYjZlNGM0NzcyMzc0NDY5NTQ3NDJiNjY1MTU5NTI0MzQ5NTk1OTY2NmU2MTYxMmY3NTYxNmI0NTczMzI0ZTc2NzU2NzQ2NTA2YjdhN2E0ZDY0NmI3MDQ5NTM2ZjQ4NWE1OTY2Njk2OTUzNTE1MzY5Nzc2NDU1NDg3NDQ5NGI3NTc3NDIzMDc3NjM2NjMzNzA3OTU0NTczNTZhMzk2NjY4MzYzNzZkNDc1Mjc4NTU1YTc5NGMyZjc0NzAzMjJiMmY0OTc2NTg0ZDM5NmI1NDc3NzI1ODRjNTQzMzY0NzM1NDQ0NjI0YTU1NDU2ZjU2NjUyYjU4NjUzNjZkNDg0OTRiNjc2ZDY5Nzc0YjZhNjg0MTMxNTQ1MTY3NDM3NzU2NGE0NzRmMzMzNjQ1N2E2OTQyNzY0YjUwNTI1NTU1NTM1MDU1MzI3YTczNGY1Mzc3NjU0ZTU4Nzg3MTZiMzYyYjMzNzA0NDQxMzY2ZTZmNmMzMzZlNzIyZjQxNTQ0ODVhMzIyZjUzNTk0Zjc1NzAzNzc3NzU0ODY3NTQ3ODc3NGM1MjUzNmMyZjZkNDc1MDRhNTAyZjU5NDc2NTU1Njk2NjQxNDk1ODc5NDU3MzQ4NzI3OTM2MzU0ZTU4NDEzNjRmMzI1MzU1NjQ2ZTY3NjI1MzdhNjE2MjY1MzA0ZDZkNjU2MTY0NDczMzM4NmY2OTU3N2E0NTU2Mzg2YzMzNTE3OTc0MzU1MzZmNDM0NDU3NmE3NjU1NzU3OTZkNTMzMTZlMzI2YzVhNDI2YzMxNTM1NDRjNDY1NDQ4NDY0YjQ5NzE1NzM5NjY0ODMyNmY1OTQ2NzQ0YzM2MzI3MDczNTM2MTc1NDU0MjY2MzI2ZTU4NTQ3OTY1NmU0ZjRlNzE3MDM0NTY0NzUzMzE1YTU2MzQ1MzQ5NzU3YTM1NDQ3MzQ1NGU2Mzc3Njc0YjRkNmIzNzUxM2QzZA==";
+	assert.instance(await subject.import(data, "some pass"), Profile);
+});
+
+test("should restore", async () => {
+	subject.flush();
+
+	const profile = subject.create("John");
+	await assert.resolves(() => subject.restore(profile));
+});
+
+test("should dump", async () => {
+	const profile = subject.create("John");
+
+	assert.object(subject.dump(profile));
+});
+
+test("should restore and mark as restored", async () => {
+	subject.flush();
+
+	const profile = subject.create("John");
+
+	await subject.restore(profile);
+
+	assert.true(profile.status().isRestored());
+});
+
+test("should persist profile and reset dirty status", async () => {
+	subject.flush();
+
+	const profile = subject.create("John");
+	profile.status().markAsRestored();
+	profile.status().markAsDirty();
+
+	assert.true(profile.status().isDirty());
+
+	subject.persist(profile);
+
+	assert.false(profile.status().isDirty());
+});
+
+test("should not save profile data if profile is not restored", async () => {
+	subject.flush();
+
+	const profile = subject.create("John");
+	profile.status().reset();
+
+	const profileAttibuteSetMock = mockery(profile.getAttributes(), "set").mockImplementation(() => {
+		return true;
 	});
 
-	test("should export ok with password", async () => {
-		const profile = subject.create("John");
-		profile.auth().setPassword("some pass");
-		await importByMnemonic(profile, identity.mnemonic, "ARK", "ark.devnet");
+	assert.false(profile.status().isRestored());
+	profileAttibuteSetMock.calledTimes(0);
 
-		const exported = subject.export(
-			profile,
-			{
-				excludeEmptyWallets: false,
-				excludeLedgerWallets: false,
-				addNetworkInformation: true,
-				saveGeneralSettings: true,
-			},
-			"some pass",
-		);
+	subject.persist(profile);
 
-		assert.string(exported);
+	assert.false(profile.status().isRestored());
+	profileAttibuteSetMock.calledTimes(0);
+});
+
+test("should not save profile data if profile is not marked as dirty", async () => {
+	subject.flush();
+
+	const profile = subject.create("John");
+
+	const profileAttibuteSetMock = mockery(profile.getAttributes(), "set").mockImplementation(() => {
+		return true;
 	});
 
-	test("should import ok", async () => {
-		const data =
-			"eyJpZCI6Ijc5YzViNWE1LTdlM2QtNDhlNC1hNjkwLWM2OTA5MzA1NDA0OSIsImNvbnRhY3RzIjp7fSwiZGF0YSI6e30sImV4Y2hhbmdlVHJhbnNhY3Rpb25zIjp7fSwibm90aWZpY2F0aW9ucyI6e30sInBlZXJzIjp7fSwicGx1Z2lucyI6e30sInNldHRpbmdzIjp7IkFDQ0VOVF9DT0xPUiI6ImdyZWVuIiwiQURWQU5DRURfTU9ERSI6ZmFsc2UsIkFVVE9NQVRJQ19TSUdOX09VVF9QRVJJT0QiOjE1LCJCSVAzOV9MT0NBTEUiOiJlbmdsaXNoIiwiREFTSEJPQVJEX1RSQU5TQUNUSU9OX0hJU1RPUlkiOmZhbHNlLCJET19OT1RfU0hPV19GRUVfV0FSTklORyI6ZmFsc2UsIkVSUk9SX1JFUE9SVElORyI6ZmFsc2UsIkVYQ0hBTkdFX0NVUlJFTkNZIjoiQlRDIiwiTE9DQUxFIjoiZW4tVVMiLCJNQVJLRVRfUFJPVklERVIiOiJjcnlwdG9jb21wYXJlIiwiTkFNRSI6IkpvaG4iLCJTQ1JFRU5TSE9UX1BST1RFQ1RJT04iOnRydWUsIlRIRU1FIjoibGlnaHQiLCJUSU1FX0ZPUk1BVCI6Img6bW0gQSIsIlVTRV9URVNUX05FVFdPUktTIjpmYWxzZX0sIndhbGxldHMiOnsiMjRjMTExNDctMGU3ZC00NmEwLWFjNzEtMjRlZGE4YzFmNGJmIjp7ImlkIjoiMjRjMTExNDctMGU3ZC00NmEwLWFjNzEtMjRlZGE4YzFmNGJmIiwiZGF0YSI6eyJDT0lOIjoiQVJLIiwiTkVUV09SSyI6ImFyay5kZXZuZXQiLCJBRERSRVNTIjoiRDYxbWZTZ2d6YnZRZ1RVZTZKaFlLSDJkb0hhcUozRHlpYiIsIlBVQkxJQ19LRVkiOiIwMzQxNTFhM2VjNDZiNTY3MGE2ODJiMGE2MzM5NGY4NjM1ODdkMWJjOTc0ODNiMWI2YzcwZWI1OGU3ZjBhZWQxOTIiLCJCQUxBTkNFIjp7ImF2YWlsYWJsZSI6IjU1ODI3MDkzNDQ0NTU2IiwiZmVlcyI6IjU1ODI3MDkzNDQ0NTU2In0sIkJST0FEQ0FTVEVEX1RSQU5TQUNUSU9OUyI6e30sIkRFUklWQVRJT05fVFlQRSI6ImJpcDM5IiwiSU1QT1JUX01FVEhPRCI6IkJJUDM5Lk1ORU1PTklDIiwiU0VRVUVOQ0UiOiIxMTE5MzIiLCJTSUdORURfVFJBTlNBQ1RJT05TIjp7fSwiVk9URVMiOltdLCJWT1RFU19BVkFJTEFCTEUiOjAsIlZPVEVTX1VTRUQiOjAsIldBSVRJTkdfRk9SX09VUl9TSUdOQVRVUkVfVFJBTlNBQ1RJT05TIjp7fSwiV0FJVElOR19GT1JfT1RIRVJfU0lHTkFUVVJFU19UUkFOU0FDVElPTlMiOnt9LCJTVEFSUkVEIjpmYWxzZX0sInNldHRpbmdzIjp7IkFWQVRBUiI6IjxzdmcgdmVyc2lvbj1cIjEuMVwiIHhtbG5zPVwiaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmdcIiBjbGFzcz1cInBpY2Fzc29cIiB3aWR0aD1cIjEwMFwiIGhlaWdodD1cIjEwMFwiIHZpZXdCb3g9XCIwIDAgMTAwIDEwMFwiPjxzdHlsZT4ucGljYXNzbyBjaXJjbGV7bWl4LWJsZW5kLW1vZGU6c29mdC1saWdodDt9PC9zdHlsZT48cmVjdCBmaWxsPVwicmdiKDIzMywgMzAsIDk5KVwiIHdpZHRoPVwiMTAwXCIgaGVpZ2h0PVwiMTAwXCIvPjxjaXJjbGUgcj1cIjUwXCIgY3g9XCI2MFwiIGN5PVwiNDBcIiBmaWxsPVwicmdiKDEzOSwgMTk1LCA3NClcIi8+PGNpcmNsZSByPVwiNDVcIiBjeD1cIjBcIiBjeT1cIjMwXCIgZmlsbD1cInJnYigwLCAxODgsIDIxMilcIi8+PGNpcmNsZSByPVwiNDBcIiBjeD1cIjkwXCIgY3k9XCI1MFwiIGZpbGw9XCJyZ2IoMjU1LCAxOTMsIDcpXCIvPjwvc3ZnPiJ9fX19";
-		assert.instance(await subject.import(data), Profile);
-	});
+	profile.status().reset();
+	assert.false(profile.status().isRestored());
+	assert.false(profile.status().isDirty());
+	profileAttibuteSetMock.calledTimes(0);
 
-	test("should import ok with password", async () => {
-		const data =
-			"ZGU2YTQ3YjQ0NzZkMzZmODEyMzlkMjM0Mzg1Zjc1M2U6NGU3NDYzNjQ3MDRhNDczMDQ1NmQ1MzRhNGMzODRjNDE3NDRkNTk1MjczNDIzMzc0Mzc0YjYxNDQ0YTQ4NjEzOTJiMzM1MzY2MzY0MzQ1NTI3OTJmNTk2YTM4NDczNTU1Mzk1YTc1NTMzNjQ2MzEzNjY0NDE0NDc3NzM2YTcxNzA0NjUyNzc3NTRkNTA2Yjc3Njg1MjUyNzY1YTYzN2E2ODZkNjM1NTMxNjc1NzU0NGUzMjdhNDk3NTc2NjUzNDY2NGIzNDU5MzA1ODc1MzMzOTczNzQ2ODM4NmI1NTUyNmQ0MTMzNDU1MzQyNzY3MDcwMzk3YTU2MzQ2YzRmNTI2Nzc3Mzc0ZTcxNjk1NzQ1Mzc2ZTc5NGI3NTcwNmU3YTM5MzU3MjM5MzM3NjRjNzY0OTM5MmI3NTRmNTc3NjZlNTY3MjczNzU2ZTQ1NmE2OTM3NTI0ZDM2NDE3ODQ3MzQ0ZTczNGU2ZjQ4MzM0Njc1NjU2OTRjNTU3NDdhNDM2MjZhMmY1MDQzNTI2NDQxNjU2NTQ0NDI2ZjY3NjQ1NjYyNDU3MTYxNTk2NjRmNTYzMTM0NjkzMDU2NTA2OTJiMzc2MTc3NjQ2NjZlMmI0YTc4MmI2ODQ5MzAyZjY5Mzc2MjQ2MmY0ZTRhNjg2MTYyNzIzMjUxNTU1MDczNDQ2Mzc4MzU3ODRjNzAzMDYyNWE1NzMyNmI1ODMxNzk3NDM0NjM0ZTUyMzk0NjQ1NGIzMzQ4NjE0NjczNjY0YTRlNzA0NDRkNzU3OTQ4Njc2NDM3NTM2NDMwNjkyYjJiMzI1MTQ4NmUzNzcxNjUzMjRhNjQ3OTUxNGU2NzZkMzc1NjRiMzg3MDMyMzc0Zjc3NTE3OTMzNzc0ZjRhNGQzMDc2Nzc0NjYyMmY0ZTQ5NGE1OTU1Mzk0OTc4NzU3Mjc0NmE2OTU4NGQ1NDcwNTIzNzQ1NmE1NjM3NWE2YTRmNjg2OTRiNjY2ODM2Njg1YTY1NzI1MzRmNzkzMjQ1NTE2NTRmMzQ0ODY2NjE2ZjVhMzYyZjczMmI0ZTU2NDkzNjU1NzY3MDM4NDE2YTRhNmM0ZDc2NDU0MjVhNzEyZjY1NGY3NjQ0NjkzMjRjMmI3OTUxNzQzMDYxNDI2ZjY4MzQ0ZDc4NjkzMjQ0NjM0ZjMzNjk3NjY0NDc1MDZkNmY0MTRjNmQ3NTY5NzU2ZTdhNmE1NDRmNGY0YzQ3NjI1ODMxNDIzNTQ4NmQ2YjM4NzA3YTc0NTU0ODYyNDUzOTRiNzg1NTQ3NjI3NzRlNDg0MjU2MzU2OTZiNjg3NDUzMzkzMTM2NmU2ZDRhMzk0MTc0NzU0MjQ3NmMzNjUyNTc1MjM4NGE2NjQzNzA0NTM1MzczNTQxNDg0ZDYxNzI0ODM1NWE0YTRiNDE0NDZlNjY2NDRkNGQ3MTUxNmM3MjcwNGM2YzRhNjU1MjQ4Mzg3YTZiNmI1MTU2Mzc2YzU2NTU3ODVhNjM3NDJiNmQ1MjM2NTI1MDY2NGQyYjUzNTkzNDM1NmI2YTYxNzY2MjQ4NzQzNTQ3NDE2ZjU3NjU2NzM2NTE0OTQzNjMzNDc0NDI1MDRiMmY0ZDYxNDU1YTQyNmQ2MzQyNjU1NDU3NzA0NzRkNjc1NjZkNTc0Njc0NGEzOTM1NzQ0NzVhNzY2ZDVhNGQ3NDUyNWE0ZjQyNTQ2NzU3NDI3MjM0NmU1ODYzMzMzMDU4NDg3NTUxNGY1MTZlNDM2ZjRhNmEyYjcyNzY0YTc4NTI3NTRmNmM2ZDRhNGI2MzM2NDU0MzM4MzU1MTM2NjE3NDdhMzE3YTQzNmE0NzY0NzU1NjQxNDYzODU4MmI2NTJiNDUzNzM5Njg2OTQzNmEzNjU1NDI0MzUxMzY2ZTc3NzI0MTMxNjc3MDU4NTg2YjMzNTY1MTU2NzI0NjRiNzc2ODY4NTM3MzMyNDY2MTQ3NDE0ODRkMmI2NDM0NDEzNDMwNGI0MzQ0NmY0MTU4NmEyZjQ2NzM3MjY1NzE3MDUzNGQ1NTdhNmI1Njc4NmM0ODc5NzgzNzY2NTE0NTZhNTM2YTRlMzA0YTQ1NmM2MTQ2NGI2OTRhMzQyZjZlNmQ0NDc3NTI1NDRkNGI1NjQzNGQzMDMzNTk2NDQ3NTI3OTQ0MzU0ZDU3NDQ2MzMzNGIzOTZlMzI2NzU4NGY2OTRmMzUzMjU2NzY3MTZkMmY2YTJmNDg0NDMyNzM0ZDU1NGQyYjY0NTA1YTZlNDU0YjU0NzE3OTRiNDQ3MTQ4NTQ2NjZjNDUzODM4MzE0MTRhMzA3ODY0Nzg0YjMxNmQ0NDc0NGQ1MDY5NzM1NjZkNTg3MzRhMzg3ODY1NjY0MjcwNjQyYjUyNmY0NzU0NjE3OTQzN2E2YzU4Mzg2NTU3NWE2OTUyNTc0OTQzNDc3MDM3NGY1NDY0Nzg0ODM1NTU3OTQxNzI2NDUxNjk2MjZhNmQzNzZlNzA0NzQ5MzM3YTc5MzU0YzY2NzMzMDY5NTA2NzYxMzQ0YjY5NTUzMTU4NjI2OTM3NDQ2YzQ2NzM2Njc5Nzc3YTUyNGE2ZDMxNmI1YTM5NzA0ODQ0NmM1MTQxNWE3OTRlNTA3YTM4NTg1Mzc5NGY0NjZiNmI2ZTZjNjIzODU1NTk1MDQyNjY1NDMwNTY0MzQxNzc2ZjRjNDUzNDRmMzg0NTJmNTY2MzQ2NGQzNjVhNDM2YjZmMzEzMTM5NzgzNjMzNzU3MDY1NDIzMTU3NjIzOTc0NDY3MzYzNmIzNjMxNmY2NTM1NTg3YTY2NTY2NjY0NDYzODYxMzg1MDZiNGI3MDQxNDU2NzMwNjc3MDMwMzgyZjZiN2E2MjcxMmY0OTU0NzUzMzQ0NjU0NzZmNTU1NzM0NWE1ODRjNzYzNjZlNTI0ODQ4NGI0ZDU1NzU1MjZiMzc2ZDUyNDg2ODQ5NTE2ODQ1Mzc1NjQ4NzE1MDQ3NzgzOTM5NmE1YTQ5NWE1MzMxNGI1NTY0NjQ1MTY1NzU0NzM1NzI3NDcyNTA2OTM3NzY1NDUxNDM1NTQ5NDM0ZjY1NzA3MjRlMzQ0MTU4MzY0Yzc0Nzg1NzM0Nzk3MTJmNDIzNDc0NDk2YTQxNTI2NTZhNTQ2ZTUzNzA3OTJmNGY1YTU4NTM2ODQ0MzE1MDM4NGY1MjQ1NzAzMDMzNjU1NTJmNzc0NTQ0NmU0YTMyNDI3OTQ3NDE1NDRhNzIzMDUyNzc2MzU5NmQ2YzRlNmQ2NzMxMzQ2ZTRmNjU2MTM3NzQzNzZkNDcyYjQ0NTU0MjUzMzc3OTMzNTg1MjMyNTk2ZTZjNGY3NzU5NmE0YTY1NTI0NjUyMmI0ZDcxNGMzMzUxNmQ2MTYxNDU1NTU4NjM2Yzc2NTY0YzY5NzEzNzU2NTI2ZDRkNTYzNzU4Nzg0ZjU4NTY0MTZkNDY0ZjRkNTc1MDJiMzk3NjY0MzA3OTcwNjM3OTZjMzc3NTY0Mzc2OTMxNjc2ZjVhNDM2NjZkNmM1MTc4NjY3MTU2NDQ2NjU4NDQ3NjQyNTY1MjU3MzU0NjYxMzU0ZTVhNDI2Zjc1NTA3ODM3NjY1MTY3NjgzNjU3MzI2MzJmNmM1YTc5NTg0NTZlMzk0ZjY0NzU3ODRlNjI0OTU2NzM0YTM5NzkyZjRlNDk0ZDU5NGI2YjZmNDY1MjUxMmI3MTMxNDg3MTRlNzE0MjRmNmQ0YTdhMzg2NTM5Mzk3NTZhNDQ3NTQ2NTc1OTMzNWE0NDU4NDE1MzQzMzY0YzYzNDk0YjM1NGM3YTc5NGQ3MzM4NDc2NDQ0NTkzNzc2NmI2ZTc5Mzk2NDY3MzUyYjMyNTE0NTVhNzA0NzQ0Nzk1NTMwMzM3NzRiNmI3ODRkMzE2ZjZjMzQ0ODYxNDEzMzUwNmI2MzQ3NTk3OTQzNTE2YTU2NWE1NTQ5NGEzODRiMzI0YTU4NDg3MTcwMzI0YTU1NDU2YzZlNjg3MzQxNjc3MDUzMzk1MjZhNDU0OTczNmU2NDU1NzA1OTZmNjUzOTU5NDI0MTQxNDIzNjY4Mzc3MjUyNGQ3ODU0Mzg2MjM5NjUzMTU1Njg3MzMyNWEzNzZhNDE0ODJiNTA2NjZkNTI3MDYxNDU3NzMzNzM3MDQ1NmY0ZjYxNTc1NTZlNTc1NzQyNDc2YTczNTA0MzQ3NzU0ZjMyNzE1ODMwMzY0ZDRjNDQ3MTRlNmE2NTRmMzk2YzM5NWEzNzY3NDQ0NDcxNjg3ODRjNmQ3NjVhNDQ2MTRhNjY1NjcyNjQ1NzMxNmQzNjMzMmYzODY2NjUyZjM0NGI2YTRhNzY3MjY1NzczODcyNGE2YzQ5Mzc1MjMyNGU0OTZmNTU3NDQyNDI0NTY1NDk1OTY1NGU2ZTZjNjU1YTZlMmY1NzZkNjY3MDQ3NTc2MTZkNGQyZjU1NjU1MzU1NjgzNzQ2NWE0NzM4NDE1NzRlNDE2NzQ3NDE0ZTc3NzMzMTM3NGI2ZjYyNDU2NTc3NTc1ODU0NDMzNzQ1Njk2NDc4Mzc1OTU2MmI3MTZiNGY2OTVhMzM0MzU5NTI3NjY2NjY2ZDc3MzY0YTRlMzg0NDVhMmIzMDU5NTQ0MzcyNmMzODMyNDc1OTMxNmI1MjQ0NzczODQ3NjY1NDY4NjQ2OTUyMzMzNjcxNmU0ODcyNzg2YjM0NDEzMTU3NTg2NTQ4NDk3YTQ1NmQzNjZlNzQ0YTRhNjYyYjM4NmY2MTQ2MzAzMTZlNmE2YjRkNDQ2MzMwNzE1YTY3NGE0MjczNTk1OTU0NDY1MjUxNGUzMzUyNDM2Nzc1NzA1Mjc0NzU2OTJmMzM0ZjZkNzc1MTU1NmI3MzVhNGEzMzU3NGM1MjcyNDc1MjZhNzA3OTM5NDg0NTQzN2E1MzUxNWE2NTc3MzIzOTY3NTQzNjRjNTQ0NTczMzI0MzY0MzE0ZTUyMmI3ODRmNTA2OTcyMzQ1ODM1MzQ1MzM4NTY3MTRmMzI2ODMyNGM1MTZhNTczODZmNjIzNTcxNjYyZjc0NmUzOTdhMzU0ZTcyNTIzNzYyMzI2MzU2NTg0Nzc1Mzc0ZTMwNjk3NjcwMmI1MTc0MzI3MzY4NDM2ZjVhMzgzNjY0MmY2YjY0NjIzMDQ0MzE3MzQ4NDg3MDZjNDE1OTUwNjk0ZDU3NDk1MzM4NDQ2Njc1NGY0ZjY4NjkzMDQ1MzE2OTM0MmI3NzY5NmM1MjY1NzM2Zjc0Mzk1MDQ1MzczODM0MzU3OTU2NmM0YjRiNTI3MjYzMmIzODQyMzQ2NTcxNmQ0MjcyMzY2YjM3NTY0ODRhNTM0MjU2NTk3MDQ1NGU2NzY1NzY3NzY4MmI3ODc3NDI2YzJmNmQ3YTYxNWEyZjRhNGY0NjU0MzI1YTVhNmE3NzY5NTQ2YTRiNTA2NDUwNTU3MDY1NmM2NjZiMmY0MjY3Nzg2ZDRkNDE3MzM0MzI3NDRiNWE3Nzc4NTQ1YTUwMzE2MzU3NTY2MTZiMzE1MDQ5Njk0Mjc0NjQ3MzczNTYzMDU0NGIzMTZlNTA0NDM4NDE0ZjY4NzEzMTQyNmQzMzZlMzY2NTc1NWE0NjQ2NmMyYjUyNTU0MzQ0Nzg1MjYxNmQ3MzZlNGM3NzM1MzE2YTZhNzM0YzQ1NTA3MTc1NmQ1NDZiNGQzNzVhNTc0ZDcxNDY3MzM2NDc2ZjcwMmY0YzY5NDU2MzcwNmY0MTM4NDQzNjQ0NDc0NTQ2NzY2MzYzNjIzNjM1N2EzNzcwNmI3MjYxNDYzNDUyNmQzNDUzNjM2ODZhNjE0YjZkNzM2MzQ4NTE2ZTQxNjI2MzYxNTAzNTc5MzMyYjc1NzE1NTUxNjM0ZDQ5NGE3MTQ4NmUzMzZhNTk1NTM3NjgzMjcxNGQ0NTUyNjc2MTY0NTY2NzJmNWEzNzY3NDY1MzcyNzE0NjRmNjU2NjU1Nzk3ODMzMmY0ZTQyNjg2ZDY3NGI1NTZlNzE0YjMyNjI1NDdhNTQ1NDMzNjU2ZTZmNzE0YTY5NmE0ZTYzNjIyYjM3NzM1NDMxNGM0NDM2Nzc3NjQ3NTU1OTRjNmIzMzQ1NjM1OTUxNDY1NTc1MzI1MzQ2NGE0YTY3Mzg3NDZkNjU0ZTVhNTA1ODU5NDQ3OTZmNzk3NDczMmI3NjM4NTU0NzU1NDk1ODU2NDY1MzcxNzM1NTZiNDg2YTZmNzM2NzUzNTU0MzUzNGEzNTUzMzI0NTc1NTUyZjYyNGY0OTUwNzI3MjQ2NWEyYjM4NTE3MjY4NWEzNjQ2NzE1YTc0NjY0YTM1NDg1MTU3NjI2ZDRlNjk2NDZmNjc2NTQ5NTA0NjY1Njk3NzM3NTE3ODJmMzM0ZDcxMzI3MDY4NDM0OTU1Nzg1NDYxMzM0MjY5NjI1OTU3Nzk0MjQyNmI2NzQyMzk1MjUyNWE3NDRhNzU2NDcxNzg2ZjU0MmI0NDM0Njc1NTU4NDYzNzY5Mzk2MTc2MmI0NjdhNTg3NzM4NjczNDcyNGI0YzZkNDUzMjZhNTA0YjU0NDY1NjU4NTYzODYyNjUzNzY1NTk3OTc3NjY2Yzc1NjM0NjM1NTkzMDcwNjQ2YTVhNjU2NjQ4NjM2NjUyMzk1MjM1NjQzNjY0NmI2ODUwNTU0NTczN2E0NzRlNzE1NDRiNjU1MTdhNzU2YTUwNDMzMzMyNjg0ZDc0Njg3MjM4NTY0YzM2MzI2OTMyNjk0ZjRmMzU0NTc0NzU2YTU5Njk0ZDU4NzU1MTRiNjM2NzY2NTkzMTRmNDQ3OTM5NDE2ODJiNjE0MzcxMzMzMzZjNDE1NjQxNzk0YzRhNzk0YTRmNGE0OTQyNzc2NzJmNTI2ZTM1Nzk0ZTRjNmMzMjJiNGE2YjY3NTEzMDZmNDE1MjYyNGM0NzU3NTI0YjY3NzY1MTQxNDc3MDYyNTI0ODU2NGUzMzMyNjU3MTU1NzQ3MTJiNzM3OTJmNGU3OTU1NTgzODU0NGIzNTcyNTg1NTUyNGYzMzUwNzE1OTM1NDk2YTQ2NmM2ZjcyNjY3NzM4NDI1MjcwNDk2YjUwNTgzMzMwNTQ0MTYxNDU2OTQ3NGM3MzU4NGI1MDc1NTg2NzQyNTQzNzMzNzc3NTc2NTE2YTQ0Nzc2ZjY1MzY3ODRjMzg0ODQ1NGI0MTZiMmI3NTRkNTk2NzYzNTE2MzU0MzA1OTcwNjg2OTMwNGEzODc2NzkzNjc5NjE0NDQ4N2E0Mjc4Mzk3MjcyNTE0NzcxNmQ1MTY0MzYzNTQ0MmI0NDZjNDQ0NDUzNzk2Yzc1NTIzNDc4NGI2MjYyNDI0ODZhMzg0YTVhNzU1MDQ0NDY2NzY5NmIyYjMwNTY2Njc5NjY1NzU0Nzc0NjUzNzc3OTJmNjQ1ODJmMmY1NTc1MmY1ODU2Mzk3NjQzNGU0Nzc5NGIzNzRkNjg3NjY1NjQzNDQ0MmY0MjRiMzY2ODM0Mzg0NjczNGQyYjUxNDg2NjM4NzE1NjY2NTUyYjZlNGM0NzcyMzc0NDY5NTQ3NDJiNjY1MTU5NTI0MzQ5NTk1OTY2NmU2MTYxMmY3NTYxNmI0NTczMzI0ZTc2NzU2NzQ2NTA2YjdhN2E0ZDY0NmI3MDQ5NTM2ZjQ4NWE1OTY2Njk2OTUzNTE1MzY5Nzc2NDU1NDg3NDQ5NGI3NTc3NDIzMDc3NjM2NjMzNzA3OTU0NTczNTZhMzk2NjY4MzYzNzZkNDc1Mjc4NTU1YTc5NGMyZjc0NzAzMjJiMmY0OTc2NTg0ZDM5NmI1NDc3NzI1ODRjNTQzMzY0NzM1NDQ0NjI0YTU1NDU2ZjU2NjUyYjU4NjUzNjZkNDg0OTRiNjc2ZDY5Nzc0YjZhNjg0MTMxNTQ1MTY3NDM3NzU2NGE0NzRmMzMzNjQ1N2E2OTQyNzY0YjUwNTI1NTU1NTM1MDU1MzI3YTczNGY1Mzc3NjU0ZTU4Nzg3MTZiMzYyYjMzNzA0NDQxMzY2ZTZmNmMzMzZlNzIyZjQxNTQ0ODVhMzIyZjUzNTk0Zjc1NzAzNzc3NzU0ODY3NTQ3ODc3NGM1MjUzNmMyZjZkNDc1MDRhNTAyZjU5NDc2NTU1Njk2NjQxNDk1ODc5NDU3MzQ4NzI3OTM2MzU0ZTU4NDEzNjRmMzI1MzU1NjQ2ZTY3NjI1MzdhNjE2MjY1MzA0ZDZkNjU2MTY0NDczMzM4NmY2OTU3N2E0NTU2Mzg2YzMzNTE3OTc0MzU1MzZmNDM0NDU3NmE3NjU1NzU3OTZkNTMzMTZlMzI2YzVhNDI2YzMxNTM1NDRjNDY1NDQ4NDY0YjQ5NzE1NzM5NjY0ODMyNmY1OTQ2NzQ0YzM2MzI3MDczNTM2MTc1NDU0MjY2MzI2ZTU4NTQ3OTY1NmU0ZjRlNzE3MDM0NTY0NzUzMzE1YTU2MzQ1MzQ5NzU3YTM1NDQ3MzQ1NGU2Mzc3Njc0YjRkNmIzNzUxM2QzZA==";
-		assert.instance(await subject.import(data, "some pass"), Profile);
-	});
+	await subject.restore(profile);
+	const profileDirtyStatusMock = mockery(profile.status(), "isDirty").mockReturnValue(false);
+	subject.persist(profile);
 
-	test("should restore", async () => {
-		subject.flush();
-
-		const profile = subject.create("John");
-		await assert.resolves(() => subject.restore(profile));
-	});
-
-	test("should dump", async () => {
-		const profile = subject.create("John");
-
-		assert.object(subject.dump(profile));
-	});
-
-	test("should restore and mark as restored", async () => {
-		subject.flush();
-
-		const profile = subject.create("John");
-
-		await subject.restore(profile);
-
-		assert.true(profile.status().isRestored());
-	});
-
-	test("should persist profile and reset dirty status", async () => {
-		subject.flush();
-
-		const profile = subject.create("John");
-		profile.status().markAsRestored();
-		profile.status().markAsDirty();
-
-		assert.true(profile.status().isDirty());
-
-		subject.persist(profile);
-
-		assert.false(profile.status().isDirty());
-	});
-
-	test("should not save profile data if profile is not restored", async () => {
-		subject.flush();
-
-		const profile = subject.create("John");
-		profile.status().reset();
-
-		const profileAttibuteSetMock = mockery(profile.getAttributes(), "set").mockImplementation(() => {
-			return true;
-		});
-
-		assert.false(profile.status().isRestored());
-		profileAttibuteSetMock.calledTimes(0);
-
-		subject.persist(profile);
-
-		assert.false(profile.status().isRestored());
-		profileAttibuteSetMock.calledTimes(0);
-	});
-
-	test("should not save profile data if profile is not marked as dirty", async () => {
-		subject.flush();
-
-		const profile = subject.create("John");
-
-		const profileAttibuteSetMock = mockery(profile.getAttributes(), "set").mockImplementation(() => {
-			return true;
-		});
-
-		profile.status().reset();
-		assert.false(profile.status().isRestored());
-		assert.false(profile.status().isDirty());
-		profileAttibuteSetMock.calledTimes(0);
-
-		await subject.restore(profile);
-		const profileDirtyStatusMock = mockery(profile.status(), "isDirty").mockReturnValue(false);
-		subject.persist(profile);
-
-		assert.true(profile.status().isRestored());
-		assert.false(profile.status().isDirty());
-		profileAttibuteSetMock.calledTimes(0);
-		profileDirtyStatusMock.mockRestore();
-		profileAttibuteSetMock.mockRestore();
-	});
+	assert.true(profile.status().isRestored());
+	assert.false(profile.status().isDirty());
+	profileAttibuteSetMock.calledTimes(0);
+	profileDirtyStatusMock.mockRestore();
+	profileAttibuteSetMock.mockRestore();
 });
 
 test.run();

--- a/packages/profiles/source/profile.validator.test.js
+++ b/packages/profiles/source/profile.validator.test.js
@@ -46,103 +46,101 @@ test.before.each(() => {
 	dumper = new ProfileDumper(profile);
 });
 
-describe("#validate", () => {
-	test("should successfully validate profile data", async () => {
-		const validProfileData = {
-			id: "uuid",
-			contacts: {
-				"448042c3-a405-4895-970e-a33c6e907905": {
-					id: "448042c3-a405-4895-970e-a33c6e907905",
-					name: "John",
-					starred: false,
-					addresses: [
-						{
-							id: "3a7a9e03-c10b-4135-88e9-92e586d53e69",
-							coin: "ARK",
-							network: "ark.devnet",
-							address: "test",
-						},
-						{
-							id: "dfc3a16d-47b8-47f2-9b6f-fe4b8365a64a",
-							coin: "ARK",
-							network: "ark.mainnet",
-							address: "test",
-						},
-					],
-				},
+test("should successfully validate profile data", async () => {
+	const validProfileData = {
+		id: "uuid",
+		contacts: {
+			"448042c3-a405-4895-970e-a33c6e907905": {
+				id: "448042c3-a405-4895-970e-a33c6e907905",
+				name: "John",
+				starred: false,
+				addresses: [
+					{
+						id: "3a7a9e03-c10b-4135-88e9-92e586d53e69",
+						coin: "ARK",
+						network: "ark.devnet",
+						address: "test",
+					},
+					{
+						id: "dfc3a16d-47b8-47f2-9b6f-fe4b8365a64a",
+						coin: "ARK",
+						network: "ark.mainnet",
+						address: "test",
+					},
+				],
 			},
-			data: { key: "value" },
-			exchangeTransactions: {},
-			notifications: {},
-			plugins: {
-				data: {},
-			},
-			settings: {
-				[ProfileSetting.AccentColor]: "blue",
-				[ProfileSetting.AdvancedMode]: false,
-				[ProfileSetting.AutomaticSignOutPeriod]: 60,
-				[ProfileSetting.Bip39Locale]: "english",
-				[ProfileSetting.DashboardTransactionHistory]: false,
-				[ProfileSetting.DoNotShowFeeWarning]: false,
-				[ProfileSetting.ErrorReporting]: false,
-				[ProfileSetting.ExchangeCurrency]: "ADA",
-				[ProfileSetting.Locale]: "en-US",
-				[ProfileSetting.MarketProvider]: "coingecko",
-				[ProfileSetting.Name]: "John Doe",
-				[ProfileSetting.NewsFilters]: JSON.stringify({ categories: [], coins: ["ARK"] }),
-				[ProfileSetting.ScreenshotProtection]: false,
-				[ProfileSetting.Theme]: "dark",
-				[ProfileSetting.TimeFormat]: "HH::MM",
-				[ProfileSetting.UseExpandedTables]: false,
-				[ProfileSetting.UseNetworkWalletNames]: false,
-				[ProfileSetting.UseTestNetworks]: false,
-			},
-			wallets: {},
-		};
-
-		validator = new ProfileValidator();
-
-		assert.equal(validator.validate(validProfileData).settings, validProfileData.settings);
-	});
-
-	test("should fail to validate", async () => {
-		const corruptedProfileData = {
-			// id: 'uuid',
-			contacts: {},
+		},
+		data: { key: "value" },
+		exchangeTransactions: {},
+		notifications: {},
+		plugins: {
 			data: {},
-			exchangeTransactions: {},
-			notifications: {},
-			plugins: { data: {} },
-			settings: { NAME: "John Doe" },
-			wallets: {},
-		};
+		},
+		settings: {
+			[ProfileSetting.AccentColor]: "blue",
+			[ProfileSetting.AdvancedMode]: false,
+			[ProfileSetting.AutomaticSignOutPeriod]: 60,
+			[ProfileSetting.Bip39Locale]: "english",
+			[ProfileSetting.DashboardTransactionHistory]: false,
+			[ProfileSetting.DoNotShowFeeWarning]: false,
+			[ProfileSetting.ErrorReporting]: false,
+			[ProfileSetting.ExchangeCurrency]: "ADA",
+			[ProfileSetting.Locale]: "en-US",
+			[ProfileSetting.MarketProvider]: "coingecko",
+			[ProfileSetting.Name]: "John Doe",
+			[ProfileSetting.NewsFilters]: JSON.stringify({ categories: [], coins: ["ARK"] }),
+			[ProfileSetting.ScreenshotProtection]: false,
+			[ProfileSetting.Theme]: "dark",
+			[ProfileSetting.TimeFormat]: "HH::MM",
+			[ProfileSetting.UseExpandedTables]: false,
+			[ProfileSetting.UseNetworkWalletNames]: false,
+			[ProfileSetting.UseTestNetworks]: false,
+		},
+		wallets: {},
+	};
 
-		new Profile({
-			id: "uuid",
-			name: "name",
-			avatar: "avatar",
-			password: undefined,
-			data: Base64.encode(JSON.stringify(corruptedProfileData)),
-		});
+	validator = new ProfileValidator();
 
-		validator = new ProfileValidator();
+	assert.equal(validator.validate(validProfileData).settings, validProfileData.settings);
+});
 
-		assert.throws(() => validator.validate(corruptedProfileData));
+test("should fail to validate", async () => {
+	const corruptedProfileData = {
+		// id: 'uuid',
+		contacts: {},
+		data: {},
+		exchangeTransactions: {},
+		notifications: {},
+		plugins: { data: {} },
+		settings: { NAME: "John Doe" },
+		wallets: {},
+	};
+
+	new Profile({
+		id: "uuid",
+		name: "name",
+		avatar: "avatar",
+		password: undefined,
+		data: Base64.encode(JSON.stringify(corruptedProfileData)),
 	});
 
-	test("should apply migrations if any are set", async () => {
-		const migrationFunction = sinon.spy();
-		const migrations = { "1.0.1": migrationFunction };
+	validator = new ProfileValidator();
 
-		container.constant(Identifiers.MigrationSchemas, migrations);
-		container.constant(Identifiers.MigrationVersion, "1.0.2");
+	assert.throws(() => validator.validate(corruptedProfileData));
+});
 
-		subject = new ProfileImporter(new Profile(dumper.dump()));
+test("should apply migrations if any are set", async () => {
+	const migrationFunction = sinon.spy();
+	const migrations = { "1.0.1": migrationFunction };
 
-		await subject.import();
+	container.constant(Identifiers.MigrationSchemas, migrations);
+	container.constant(Identifiers.MigrationVersion, "1.0.2");
 
-		assert.true(migrationFunction.callCount > 0);
-	});
+	subject = new ProfileImporter(new Profile(dumper.dump()));
+
+	await subject.import();
+
+	assert.true(migrationFunction.callCount > 0);
 });
 
 test.run();

--- a/packages/profiles/source/registration.aggregate.test.js
+++ b/packages/profiles/source/registration.aggregate.test.js
@@ -35,13 +35,11 @@ test.before.each(async () => {
 	subject = new RegistrationAggregate(profile);
 });
 
-describe("RegistrationAggregate", () => {
-	test("#delegates", async () => {
-		const delegates = subject.delegates();
+test("#delegates", async () => {
+	const delegates = subject.delegates();
 
-		assert.length(delegates, 1);
-		assert.is(delegates[0].address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
-	});
+	assert.length(delegates, 1);
+	assert.is(delegates[0].address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
 });
 
 test.run();

--- a/packages/profiles/source/transaction.aggregate.test.js
+++ b/packages/profiles/source/transaction.aggregate.test.js
@@ -41,183 +41,181 @@ test.before.each(async () => {
 
 test.after(() => nock.enableNetConnect());
 
-describe("TransactionAggregate", () => {
-	// describe.each(["all", "sent", "received"])("%s", (method) => {
-	// 	test("should have more transactions", async () => {
-	// 		nock(/.+/)
-	// 			.get("/api/transactions")
-	// 			.query(true)
-	// 			.reply(200, require("../test/fixtures/client/transactions.json"));
+// describe.each(["all", "sent", "received"])("%s", (method) => {
+// 	test("should have more transactions", async () => {
+// 		nock(/.+/)
+// 			.get("/api/transactions")
+// 			.query(true)
+// 			.reply(200, require("../test/fixtures/client/transactions.json"));
 
-	// 		const result = await subject[method]();
+// 		const result = await subject[method]();
 
-	// 		assert.instance(result, ExtendedConfirmedTransactionDataCollection);
-	// 		assert.length(result.items(), 100);
-	// 		assert.is(result.items()[0].amount(), 7.99999999);
-	// 	});
+// 		assert.instance(result, ExtendedConfirmedTransactionDataCollection);
+// 		assert.length(result.items(), 100);
+// 		assert.is(result.items()[0].amount(), 7.99999999);
+// 	});
 
-	// 	test("should not have more transactions", async () => {
-	// 		nock(/.+/)
-	// 			.get("/api/transactions")
-	// 			.query(true)
-	// 			.reply(200, require("../test/fixtures/client/transactions-no-more.json"));
+// 	test("should not have more transactions", async () => {
+// 		nock(/.+/)
+// 			.get("/api/transactions")
+// 			.query(true)
+// 			.reply(200, require("../test/fixtures/client/transactions-no-more.json"));
 
-	// 		const result = await subject[method]();
+// 		const result = await subject[method]();
 
-	// 		assert.instance(result, ExtendedConfirmedTransactionDataCollection);
-	// 		assert.length(result.items(), 100);
-	// 		assert.false(subject.hasMore(method));
-	// 	});
+// 		assert.instance(result, ExtendedConfirmedTransactionDataCollection);
+// 		assert.length(result.items(), 100);
+// 		assert.false(subject.hasMore(method));
+// 	});
 
-	// 	test("should skip error responses for processing", async () => {
-	// 		nock(/.+/).get("/api/transactions").query(true).reply(404);
+// 	test("should skip error responses for processing", async () => {
+// 		nock(/.+/).get("/api/transactions").query(true).reply(404);
 
-	// 		const result = await subject[method]();
+// 		const result = await subject[method]();
 
-	// 		assert.instance(result, ExtendedConfirmedTransactionDataCollection);
-	// 		assert.length(result.items(), 0);
-	// 		assert.false(subject.hasMore(method));
-	// 	});
+// 		assert.instance(result, ExtendedConfirmedTransactionDataCollection);
+// 		assert.length(result.items(), 0);
+// 		assert.false(subject.hasMore(method));
+// 	});
 
-	// 	test("should skip empty responses for processing", async () => {
-	// 		nock(/.+/)
-	// 			.get("/api/transactions")
-	// 			.query(true)
-	// 			.reply(200, require("../test/fixtures/client/transactions-empty.json"));
+// 	test("should skip empty responses for processing", async () => {
+// 		nock(/.+/)
+// 			.get("/api/transactions")
+// 			.query(true)
+// 			.reply(200, require("../test/fixtures/client/transactions-empty.json"));
 
-	// 		const result = await subject[method]();
+// 		const result = await subject[method]();
 
-	// 		assert.instance(result, ExtendedConfirmedTransactionDataCollection);
-	// 		assert.length(result.items(), 0);
-	// 		assert.false(subject.hasMore(method));
-	// 	});
+// 		assert.instance(result, ExtendedConfirmedTransactionDataCollection);
+// 		assert.length(result.items(), 0);
+// 		assert.false(subject.hasMore(method));
+// 	});
 
-	// 	test("should fetch transactions twice and then stop because no more are available", async () => {
-	// 		nock(/.+/)
-	// 			.get("/api/transactions")
-	// 			.query(true)
-	// 			.reply(200, require("../test/fixtures/client/transactions.json"))
-	// 			.get("/api/transactions")
-	// 			.query(true)
-	// 			.reply(200, require("../test/fixtures/client/transactions-no-more.json"));
+// 	test("should fetch transactions twice and then stop because no more are available", async () => {
+// 		nock(/.+/)
+// 			.get("/api/transactions")
+// 			.query(true)
+// 			.reply(200, require("../test/fixtures/client/transactions.json"))
+// 			.get("/api/transactions")
+// 			.query(true)
+// 			.reply(200, require("../test/fixtures/client/transactions-no-more.json"));
 
-	// 		// We receive a response that does contain a "next" cursor
-	// 		const firstRequest = await subject[method]();
+// 		// We receive a response that does contain a "next" cursor
+// 		const firstRequest = await subject[method]();
 
-	// 		assert.instance(firstRequest, ExtendedConfirmedTransactionDataCollection);
-	// 		assert.length(firstRequest.items(), 100);
-	// 		assert.true(subject.hasMore(method));
+// 		assert.instance(firstRequest, ExtendedConfirmedTransactionDataCollection);
+// 		assert.length(firstRequest.items(), 100);
+// 		assert.true(subject.hasMore(method));
 
-	// 		// We receive a response that does not contain a "next" cursor
-	// 		const secondRequest = await subject[method]();
+// 		// We receive a response that does not contain a "next" cursor
+// 		const secondRequest = await subject[method]();
 
-	// 		assert.instance(secondRequest, ExtendedConfirmedTransactionDataCollection);
-	// 		assert.length(secondRequest.items(), 100);
-	// 		assert.false(subject.hasMore(method));
+// 		assert.instance(secondRequest, ExtendedConfirmedTransactionDataCollection);
+// 		assert.length(secondRequest.items(), 100);
+// 		assert.false(subject.hasMore(method));
 
-	// 		// We do not send any requests because no more data is available
-	// 		const thirdRequest = await subject[method]();
+// 		// We do not send any requests because no more data is available
+// 		const thirdRequest = await subject[method]();
 
-	// 		assert.instance(thirdRequest, ExtendedConfirmedTransactionDataCollection);
-	// 		assert.length(thirdRequest.items(), 0);
-	// 		assert.false(subject.hasMore(method));
-	// 	});
+// 		assert.instance(thirdRequest, ExtendedConfirmedTransactionDataCollection);
+// 		assert.length(thirdRequest.items(), 0);
+// 		assert.false(subject.hasMore(method));
+// 	});
 
-	// 	test("should determine if it has more transactions to be requested", async () => {
-	// 		nock(/.+/)
-	// 			.get("/api/transactions")
-	// 			.query(true)
-	// 			.reply(200, require("../test/fixtures/client/transactions.json"));
+// 	test("should determine if it has more transactions to be requested", async () => {
+// 		nock(/.+/)
+// 			.get("/api/transactions")
+// 			.query(true)
+// 			.reply(200, require("../test/fixtures/client/transactions.json"));
 
-	// 		assert.false(subject.hasMore(method));
+// 		assert.false(subject.hasMore(method));
 
-	// 		await subject[method]();
+// 		await subject[method]();
 
-	// 		assert.true(subject.hasMore(method));
-	// 	});
+// 		assert.true(subject.hasMore(method));
+// 	});
 
-	// 	test("should flush the history", async () => {
-	// 		nock(/.+/)
-	// 			.get("/api/transactions")
-	// 			.query(true)
-	// 			.reply(200, require("../test/fixtures/client/transactions.json"));
+// 	test("should flush the history", async () => {
+// 		nock(/.+/)
+// 			.get("/api/transactions")
+// 			.query(true)
+// 			.reply(200, require("../test/fixtures/client/transactions.json"));
 
-	// 		assert.false(subject.hasMore(method));
+// 		assert.false(subject.hasMore(method));
 
-	// 		await subject[method]();
+// 		await subject[method]();
 
-	// 		assert.true(subject.hasMore(method));
+// 		assert.true(subject.hasMore(method));
 
-	// 		subject.flush(method);
-	// 	});
-	// });
+// 		subject.flush(method);
+// 	});
+// });
 
-	test("should flush all the history", async () => {
-		nock(/.+/)
-			.get("/api/transactions")
-			.query(true)
-			.reply(200, require("../test/fixtures/client/transactions.json"));
+test("should flush all the history", async () => {
+	nock(/.+/)
+		.get("/api/transactions")
+		.query(true)
+		.reply(200, require("../test/fixtures/client/transactions.json"));
 
-		assert.false(subject.hasMore("transactions"));
+	assert.false(subject.hasMore("transactions"));
 
-		await subject.all();
+	await subject.all();
 
-		assert.true(subject.hasMore("all"));
+	assert.true(subject.hasMore("all"));
 
-		subject.flush();
+	subject.flush();
+});
+
+test("should handle undefined  promiseAllSettledByKey responses in aggregate", async () => {
+	nock(/.+/)
+		.get("/api/transactions")
+		.query(true)
+		.reply(200, require("../test/fixtures/client/transactions.json"));
+
+	const promiseAllSettledByKeyMock = mockery(promiseHelpers, "promiseAllSettledByKey").mockImplementation(() => {
+		return Promise.resolve(undefined);
 	});
 
-	test("should handle undefined  promiseAllSettledByKey responses in aggregate", async () => {
-		nock(/.+/)
-			.get("/api/transactions")
-			.query(true)
-			.reply(200, require("../test/fixtures/client/transactions.json"));
+	const results = await subject.all();
+	assert.instance(results, ExtendedConfirmedTransactionDataCollection);
+	promiseAllSettledByKeyMock.mockRestore();
+});
 
-		const promiseAllSettledByKeyMock = mockery(promiseHelpers, "promiseAllSettledByKey").mockImplementation(() => {
-			return Promise.resolve(undefined);
-		});
+test("should aggregate and filter transactions based on provided identifiers of type `address`", async () => {
+	nock(/.+/)
+		.get("/api/transactions")
+		.query(true)
+		.reply(200, require("../test/fixtures/client/transactions.json"));
 
-		const results = await subject.all();
-		assert.instance(results, ExtendedConfirmedTransactionDataCollection);
-		promiseAllSettledByKeyMock.mockRestore();
+	const result = await subject.all({
+		identifiers: [{ type: "address", value: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW" }],
 	});
 
-	test("should aggregate and filter transactions based on provided identifiers of type `address`", async () => {
-		nock(/.+/)
-			.get("/api/transactions")
-			.query(true)
-			.reply(200, require("../test/fixtures/client/transactions.json"));
+	assert.instance(result, ExtendedConfirmedTransactionDataCollection);
+	assert.length(result.items(), 100);
 
-		const result = await subject.all({
-			identifiers: [{ type: "address", value: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW" }],
-		});
+	subject.flush();
+});
 
-		assert.instance(result, ExtendedConfirmedTransactionDataCollection);
-		assert.length(result.items(), 100);
+test("should aggregate and filter transactions based on provided identifiers of type `extendedPublicKey`", async () => {
+	nock(/.+/)
+		.get("/api/transactions")
+		.query(true)
+		.reply(200, require("../test/fixtures/client/transactions.json"));
 
-		subject.flush();
+	const result = await subject.all({
+		identifiers: [
+			{
+				type: "extendedPublicKey",
+				value: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
+			},
+		],
 	});
 
-	test("should aggregate and filter transactions based on provided identifiers of type `extendedPublicKey`", async () => {
-		nock(/.+/)
-			.get("/api/transactions")
-			.query(true)
-			.reply(200, require("../test/fixtures/client/transactions.json"));
+	assert.instance(result, ExtendedConfirmedTransactionDataCollection);
+	assert.length(result.items(), 100);
 
-		const result = await subject.all({
-			identifiers: [
-				{
-					type: "extendedPublicKey",
-					value: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
-				},
-			],
-		});
-
-		assert.instance(result, ExtendedConfirmedTransactionDataCollection);
-		assert.length(result.items(), 100);
-
-		subject.flush();
-	});
+	subject.flush();
 });
 
 test.run();

--- a/packages/profiles/source/transaction.aggregate.test.js
+++ b/packages/profiles/source/transaction.aggregate.test.js
@@ -152,10 +152,7 @@ test.after(() => nock.enableNetConnect());
 // });
 
 test("should flush all the history", async () => {
-	nock(/.+/)
-		.get("/api/transactions")
-		.query(true)
-		.reply(200, require("../test/fixtures/client/transactions.json"));
+	nock(/.+/).get("/api/transactions").query(true).reply(200, require("../test/fixtures/client/transactions.json"));
 
 	assert.false(subject.hasMore("transactions"));
 
@@ -167,10 +164,7 @@ test("should flush all the history", async () => {
 });
 
 test("should handle undefined  promiseAllSettledByKey responses in aggregate", async () => {
-	nock(/.+/)
-		.get("/api/transactions")
-		.query(true)
-		.reply(200, require("../test/fixtures/client/transactions.json"));
+	nock(/.+/).get("/api/transactions").query(true).reply(200, require("../test/fixtures/client/transactions.json"));
 
 	const promiseAllSettledByKeyMock = mockery(promiseHelpers, "promiseAllSettledByKey").mockImplementation(() => {
 		return Promise.resolve(undefined);
@@ -182,10 +176,7 @@ test("should handle undefined  promiseAllSettledByKey responses in aggregate", a
 });
 
 test("should aggregate and filter transactions based on provided identifiers of type `address`", async () => {
-	nock(/.+/)
-		.get("/api/transactions")
-		.query(true)
-		.reply(200, require("../test/fixtures/client/transactions.json"));
+	nock(/.+/).get("/api/transactions").query(true).reply(200, require("../test/fixtures/client/transactions.json"));
 
 	const result = await subject.all({
 		identifiers: [{ type: "address", value: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW" }],
@@ -198,10 +189,7 @@ test("should aggregate and filter transactions based on provided identifiers of 
 });
 
 test("should aggregate and filter transactions based on provided identifiers of type `extendedPublicKey`", async () => {
-	nock(/.+/)
-		.get("/api/transactions")
-		.query(true)
-		.reply(200, require("../test/fixtures/client/transactions.json"));
+	nock(/.+/).get("/api/transactions").query(true).reply(200, require("../test/fixtures/client/transactions.json"));
 
 	const result = await subject.all({
 		identifiers: [

--- a/packages/profiles/source/transaction.dto.test.js
+++ b/packages/profiles/source/transaction.dto.test.js
@@ -50,7 +50,7 @@ let wallet;
 let liveSpy;
 let testSpy;
 
-test.before(async () => {
+const beforeEachCallback = async () => {
 	bootContainer();
 
 	nock.disableNetConnect();
@@ -80,9 +80,7 @@ test.before(async () => {
 		.query(true)
 		.reply(200, require("../test/fixtures/markets/cryptocompare/historical.json"))
 		.persist();
-});
 
-test.before.each(async () => {
 	profile = new Profile({ id: "profile-id", name: "name", avatar: "avatar", data: "" });
 
 	profile.settings().set(ProfileSetting.Name, "John Doe");
@@ -93,15 +91,25 @@ test.before.each(async () => {
 
 	liveSpy = mockery(wallet.network(), "isLive").mockReturnValue(true);
 	testSpy = mockery(wallet.network(), "isTest").mockReturnValue(false);
-});
+}
 
-test.after.each(() => {
+const afterEachCallback = () => {
 	liveSpy.mockRestore();
 	testSpy.mockRestore();
-});
+}
 
-describe("Transaction", () => {
-	test.before.each(() => (subject = createSubject(wallet, undefined, ExtendedConfirmedTransactionData)));
+describe("Transaction", ({ afterEach, beforeEach, test }) => {
+	beforeEach(async () => {
+		await beforeEachCallback();
+
+		subject = createSubject(wallet, undefined, ExtendedConfirmedTransactionData);
+	});
+
+	afterEach(() => {
+		container.flush();
+
+		afterEachCallback();
+	});
 
 	test("should have an explorer link", () => {
 		assert.is(subject.explorerLink(), "https://dexplorer.ark.io/transaction/transactionId");
@@ -438,8 +446,8 @@ describe("Transaction", () => {
 	// });
 });
 
-// describe("DelegateRegistrationData", () => {
-// 	test.before.each(() => {
+// describe("DelegateRegistrationData", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(() => {
 // 		subject = createSubject(
 // 			wallet,
 // 			{
@@ -454,7 +462,7 @@ describe("Transaction", () => {
 // 	});
 // });
 
-// describe("DelegateResignationData", () => {
+// describe("DelegateResignationData", ({ afterEach, beforeEach, test }) => {
 // 	test.before.each(() => (subject = createSubject(wallet, undefined, ExtendedConfirmedTransactionData)));
 
 // 	test("#id", () => {
@@ -462,8 +470,8 @@ describe("Transaction", () => {
 // 	});
 // });
 
-// describe("HtlcClaimData", () => {
-// 	test.before.each(() => {
+// describe("HtlcClaimData", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(() => {
 // 		subject = createSubject(
 // 			wallet,
 // 			{
@@ -483,8 +491,8 @@ describe("Transaction", () => {
 // 	});
 // });
 
-// describe("HtlcLockData", () => {
-// 	test.before.each(() => {
+// describe("HtlcLockData", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(() => {
 // 		subject = createSubject(
 // 			wallet,
 // 			{
@@ -509,8 +517,8 @@ describe("Transaction", () => {
 // 	});
 // });
 
-// describe("HtlcRefundData", () => {
-// 	test.before.each(() => {
+// describe("HtlcRefundData", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(() => {
 // 		subject = createSubject(
 // 			wallet,
 // 			{
@@ -525,8 +533,8 @@ describe("Transaction", () => {
 // 	});
 // });
 
-// describe("IpfsData", () => {
-// 	test.before.each(() => {
+// describe("IpfsData", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(() => {
 // 		subject = createSubject(
 // 			wallet,
 // 			{
@@ -541,8 +549,8 @@ describe("Transaction", () => {
 // 	});
 // });
 
-// describe("MultiPaymentData", () => {
-// 	test.before.each(() => {
+// describe("MultiPaymentData", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(() => {
 // 		subject = createSubject(
 // 			wallet,
 // 			{
@@ -557,8 +565,8 @@ describe("Transaction", () => {
 // 	});
 // });
 
-// describe("MultiSignatureData", () => {
-// 	test.before.each(() => {
+// describe("MultiSignatureData", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(() => {
 // 		subject = createSubject(
 // 			wallet,
 // 			{
@@ -578,8 +586,8 @@ describe("Transaction", () => {
 // 	});
 // });
 
-// describe("SecondSignatureData", () => {
-// 	test.before.each(() => {
+// describe("SecondSignatureData", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(() => {
 // 		subject = createSubject(
 // 			wallet,
 // 			{
@@ -594,24 +602,30 @@ describe("Transaction", () => {
 // 	});
 // });
 
-describe("TransferData", () => {
-	test.before.each(() => {
-		subject = createSubject(
-			wallet,
-			{
-				memo: () => "memo",
-			},
-			ExtendedConfirmedTransactionData,
-		);
-	});
+// describe("TransferData", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(async () => {
+// 		beforeEachCallback();
 
-	test("#memo", () => {
-		assert.is(subject.memo(), "memo");
-	});
-});
+// 		subject = createSubject(
+// 			wallet,
+// 			{
+// 				memo: () => "memo",
+// 			},
+// 			ExtendedConfirmedTransactionData,
+// 		);
+// 	});
 
-// describe("VoteData", () => {
-// 	test.before.each(() => {
+// 	afterEach(() => {
+// 		afterEachCallback();
+// 	});
+
+// 	test("#memo", () => {
+// 		assert.is(subject.memo(), "memo");
+// 	});
+// });
+
+// describe("VoteData", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(() => {
 // 		subject = createSubject(
 // 			wallet,
 // 			{
@@ -631,8 +645,8 @@ describe("TransferData", () => {
 // 	});
 // });
 
-// describe("Type Specific", () => {
-// 	test.before.each(() => {
+// describe("Type Specific", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(() => {
 // 		subject = createSubject(
 // 			wallet,
 // 			{

--- a/packages/profiles/source/transaction.dto.test.js
+++ b/packages/profiles/source/transaction.dto.test.js
@@ -91,12 +91,12 @@ const beforeEachCallback = async () => {
 
 	liveSpy = mockery(wallet.network(), "isLive").mockReturnValue(true);
 	testSpy = mockery(wallet.network(), "isTest").mockReturnValue(false);
-}
+};
 
 const afterEachCallback = () => {
 	liveSpy.mockRestore();
 	testSpy.mockRestore();
-}
+};
 
 describe("Transaction", ({ afterEach, beforeEach, test }) => {
 	beforeEach(async () => {

--- a/packages/profiles/source/transaction.mapper.test.js
+++ b/packages/profiles/source/transaction.mapper.test.js
@@ -32,7 +32,7 @@ const data = [
 
 test.before(() => bootContainer());
 
-describe("transaction-mapper", () => {
+describe("transaction-mapper", ({ afterEach, beforeEach, test }) => {
 	let profile;
 	let wallet;
 

--- a/packages/profiles/source/wallet-transaction.service.test.js
+++ b/packages/profiles/source/wallet-transaction.service.test.js
@@ -22,85 +22,79 @@ let profile;
 let wallet;
 let subject;
 
-test.before(() => {
-	bootContainer();
+describe("ARK", ({ afterEach, beforeAll, beforeEach, test }) => {
+	beforeAll(() => {
+		bootContainer();
 
-	nock.disableNetConnect();
-});
+		nock.disableNetConnect();
+	});
 
-test.before.each(() => {
-	nock("https://ark-test.payvo.com:443")
-		.get("/api/blockchain")
-		.reply(200, require("../test/fixtures/client/blockchain.json"))
-		.get("/api/node/configuration")
-		.reply(200, require("../test/fixtures/client/configuration.json"))
-		.get("/api/peers")
-		.reply(200, require("../test/fixtures/client/peers.json"))
-		.get("/api/node/configuration/crypto")
-		.reply(200, require("../test/fixtures/client/cryptoConfiguration.json"))
-		.get("/api/node/syncing")
-		.reply(200, require("../test/fixtures/client/syncing.json"))
-		// default wallet
-		.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")
-		.reply(200, require("../test/fixtures/client/wallet.json"))
-		.get("/api/wallets/030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd")
-		.reply(200, require("../test/fixtures/client/wallet.json"))
-		// second wallet
-		.get("/api/wallets/022e04844a0f02b1df78dff2c7c4e3200137dfc1183dcee8fc2a411b00fd1877ce")
-		.reply(200, require("../test/fixtures/client/wallet-2.json"))
-		.get("/api/wallets/DNc92FQmYu8G9Xvo6YqhPtRxYsUxdsUn9w")
-		.reply(200, require("../test/fixtures/client/wallet-2.json"))
-		// Musig wallet
-		.get("/api/wallets/DML7XEfePpj5qDFb1SbCWxLRhzdTDop7V1")
-		.reply(200, require("../test/fixtures/client/wallet-musig.json"))
-		.get("/api/wallets/02cec9caeb855e54b71e4d60c00889e78107f6136d1f664e5646ebcb2f62dae2c6")
-		.reply(200, require("../test/fixtures/client/wallet-musig.json"))
-		.get("/transaction/a7245dcc720d3e133035cff04b4a14dbc0f8ff889c703c89c99f2f03e8f3c59d")
-		.query(true)
-		.reply(200, require("../test/fixtures/client/musig-transaction.json"))
-		.get("/transaction/bb9004fa874b534905f9eff201150f7f982622015f33e076c52f1e945ef184ed")
-		.query(true)
-		.reply(200, () => ({ data: require("../test/fixtures/client/transactions.json").data[1] }))
-		.persist();
+	beforeEach(async () => {
+		nock("https://ark-test.payvo.com:443")
+			.get("/api/blockchain")
+			.reply(200, require("../test/fixtures/client/blockchain.json"))
+			.get("/api/node/configuration")
+			.reply(200, require("../test/fixtures/client/configuration.json"))
+			.get("/api/peers")
+			.reply(200, require("../test/fixtures/client/peers.json"))
+			.get("/api/node/configuration/crypto")
+			.reply(200, require("../test/fixtures/client/cryptoConfiguration.json"))
+			.get("/api/node/syncing")
+			.reply(200, require("../test/fixtures/client/syncing.json"))
+			// default wallet
+			.get("/api/wallets/D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW")
+			.reply(200, require("../test/fixtures/client/wallet.json"))
+			.get("/api/wallets/030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd")
+			.reply(200, require("../test/fixtures/client/wallet.json"))
+			// second wallet
+			.get("/api/wallets/022e04844a0f02b1df78dff2c7c4e3200137dfc1183dcee8fc2a411b00fd1877ce")
+			.reply(200, require("../test/fixtures/client/wallet-2.json"))
+			.get("/api/wallets/DNc92FQmYu8G9Xvo6YqhPtRxYsUxdsUn9w")
+			.reply(200, require("../test/fixtures/client/wallet-2.json"))
+			// Musig wallet
+			.get("/api/wallets/DML7XEfePpj5qDFb1SbCWxLRhzdTDop7V1")
+			.reply(200, require("../test/fixtures/client/wallet-musig.json"))
+			.get("/api/wallets/02cec9caeb855e54b71e4d60c00889e78107f6136d1f664e5646ebcb2f62dae2c6")
+			.reply(200, require("../test/fixtures/client/wallet-musig.json"))
+			.get("/transaction/a7245dcc720d3e133035cff04b4a14dbc0f8ff889c703c89c99f2f03e8f3c59d")
+			.query(true)
+			.reply(200, require("../test/fixtures/client/musig-transaction.json"))
+			.get("/transaction/bb9004fa874b534905f9eff201150f7f982622015f33e076c52f1e945ef184ed")
+			.query(true)
+			.reply(200, () => ({ data: require("../test/fixtures/client/transactions.json").data[1] }))
+			.persist();
 
-	nock("https://lsk-test.payvo.com:443")
-		.get("/api/v2/accounts")
-		.query({ address: "lskw6h7zzen4f7n8k4ntwd9qtv62gexzv2rh7cb6h" })
-		.reply(404, { error: true, message: "Data not found" })
-		.get("/api/v2/fees")
-		.reply(200, {
-			data: {
-				feeEstimatePerByte: {
-					low: 0,
-					medium: 0,
-					high: 0,
+		nock("https://lsk-test.payvo.com:443")
+			.get("/api/v2/accounts")
+			.query({ address: "lskw6h7zzen4f7n8k4ntwd9qtv62gexzv2rh7cb6h" })
+			.reply(404, { error: true, message: "Data not found" })
+			.get("/api/v2/fees")
+			.reply(200, {
+				data: {
+					feeEstimatePerByte: {
+						low: 0,
+						medium: 0,
+						high: 0,
+					},
+					baseFeeById: {
+						"5:0": "1000000000",
+					},
+					baseFeeByName: {
+						"dpos:registerDelegate": "1000000000",
+					},
+					minFeePerByte: 1000,
 				},
-				baseFeeById: {
-					"5:0": "1000000000",
+				meta: {
+					lastUpdate: 1630294530,
+					lastBlockHeight: 14467510,
+					lastBlockId: "0ccc6783e26b8fbf030d9d23c6df35c2db58395b2d7aab9b61a703798425be40",
 				},
-				baseFeeByName: {
-					"dpos:registerDelegate": "1000000000",
-				},
-				minFeePerByte: 1000,
-			},
-			meta: {
-				lastUpdate: 1630294530,
-				lastBlockHeight: 14467510,
-				lastBlockId: "0ccc6783e26b8fbf030d9d23c6df35c2db58395b2d7aab9b61a703798425be40",
-			},
-		})
-		.persist();
+			})
+			.persist();
 
-	profile = new Profile({ id: "profile-id", name: "name", avatar: "avatar", data: "" });
-	profile.settings().set(ProfileSetting.Name, "John Doe");
-});
+		profile = new Profile({ id: "profile-id", name: "name", avatar: "avatar", data: "" });
+		profile.settings().set(ProfileSetting.Name, "John Doe");
 
-test.after.each(() => {
-	nock.cleanAll();
-});
-
-describe("ARK", (suite) => {
-	test.before.each(async () => {
 		wallet = await profile.walletFactory().fromMnemonicWithBIP39({
 			coin: "ARK",
 			network: "ark.devnet",
@@ -110,273 +104,275 @@ describe("ARK", (suite) => {
 		subject = new TransactionService(wallet);
 	});
 
+	afterEach(() => {
+		nock.cleanAll();
+	});
+
 	test("should sync", async () => {
 		const musig = require("../test/fixtures/client/musig-transaction.json");
 		nock("https://ark-test.payvo.com:443").get("/transactions").query(true).reply(200, [musig]).persist();
 		await assert.resolves(() => subject.sync());
 	});
 
-	describe("signatures", () => {
-		test("should add signature", async () => {
-			nock("https://ark-test-musig.payvo.com:443")
-				.post("/", {
-					publicKey: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
-					state: "pending",
-				})
-				.reply(200, {
-					result: [
-						{
-							data: {
-								id: "505e385d08e211b83fa6cf304ad67f42ddbdb364d767fd65354eb5a620b9380f",
-								signatures: [],
-							},
-							multisigAsset: {},
+	test("should add signature", async () => {
+		nock("https://ark-test-musig.payvo.com:443")
+			.post("/", {
+				publicKey: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
+				state: "pending",
+			})
+			.reply(200, {
+				result: [
+					{
+						data: {
+							id: "505e385d08e211b83fa6cf304ad67f42ddbdb364d767fd65354eb5a620b9380f",
+							signatures: [],
 						},
-					],
-				})
-				.post("/", {
-					publicKey: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
-					state: "ready",
-				})
-				.reply(200, {
-					result: [
-						{
-							data: {
-								id: "505e385d08e211b83fa6cf304ad67f42ddbdb364d767fd65354eb5a620b9380f",
-								signatures: [],
-							},
-							multisigAsset: {},
-						},
-					],
-				})
-				.post("/", {
-					id: "505e385d08e211b83fa6cf304ad67f42ddbdb364d767fd65354eb5a620b9380f",
-				})
-				.reply(200, {
-					result: {
-						data: { signatures: [] },
 						multisigAsset: {},
 					},
-				})
-				.post("/", ({ method }) => method === "store")
-				.reply(200, {
-					result: {
-						id: "505e385d08e211b83fa6cf304ad67f42ddbdb364d767fd65354eb5a620b9380f",
+				],
+			})
+			.post("/", {
+				publicKey: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
+				state: "ready",
+			})
+			.reply(200, {
+				result: [
+					{
+						data: {
+							id: "505e385d08e211b83fa6cf304ad67f42ddbdb364d767fd65354eb5a620b9380f",
+							signatures: [],
+						},
+						multisigAsset: {},
 					},
-				})
-				.persist();
-
-			const identity1 = await deriveIdentity(
-				"citizen door athlete item name various drive onion foster audit board myself",
-			);
-			const identity2 = await deriveIdentity(
-				"upset boat motor few ketchup merge punch gesture lecture piano neutral uniform",
-			);
-
-			const id = await subject.signMultiSignature({
-				nonce: "1",
-				signatory: new Signatories.Signatory(new Signatories.MnemonicSignatory(identity1)),
-				data: {
-					publicKeys: [identity1.publicKey, identity2.publicKey],
-					min: 1,
-					senderPublicKey: "0205d9bbe71c343ac9a6a83a4344fd404c3534fc7349827097d0835d160bc2b896",
+				],
+			})
+			.post("/", {
+				id: "505e385d08e211b83fa6cf304ad67f42ddbdb364d767fd65354eb5a620b9380f",
+			})
+			.reply(200, {
+				result: {
+					data: { signatures: [] },
+					multisigAsset: {},
 				},
-			});
-
-			await subject.sync();
-			await subject.addSignature(id, new Signatories.Signatory(new Signatories.MnemonicSignatory(identity2)));
-
-			assert.defined(subject.transaction(id));
-		});
-
-		test("should sign second signature", async () => {
-			const input = {
-				nonce: "1",
-				signatory: new Signatories.Signatory(
-					new Signatories.MnemonicSignatory({
-						signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
-						address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-						publicKey: "publicKey",
-						privateKey: "privateKey",
-					}),
-				),
-				data: {
-					mnemonic: "this is a top secret second mnemonic",
+			})
+			.post("/", ({ method }) => method === "store")
+			.reply(200, {
+				result: {
+					id: "505e385d08e211b83fa6cf304ad67f42ddbdb364d767fd65354eb5a620b9380f",
 				},
-			};
-			const id = await subject.signSecondSignature(input);
+			})
+			.persist();
 
-			assert.string(id);
-			assert.containKey(subject.signed(), id);
-			assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
+		const identity1 = await deriveIdentity(
+			"citizen door athlete item name various drive onion foster audit board myself",
+		);
+		const identity2 = await deriveIdentity(
+			"upset boat motor few ketchup merge punch gesture lecture piano neutral uniform",
+		);
+
+		const id = await subject.signMultiSignature({
+			nonce: "1",
+			signatory: new Signatories.Signatory(new Signatories.MnemonicSignatory(identity1)),
+			data: {
+				publicKeys: [identity1.publicKey, identity2.publicKey],
+				min: 1,
+				senderPublicKey: "0205d9bbe71c343ac9a6a83a4344fd404c3534fc7349827097d0835d160bc2b896",
+			},
 		});
 
-		test("should sign multi signature registration", async () => {
-			const identity1 = await deriveIdentity(
-				"upset boat motor few ketchup merge punch gesture lecture piano neutral uniform",
-			);
-			const identity2 = await deriveIdentity(
-				"citizen door athlete item name various drive onion foster audit board myself",
-			);
-			const identity3 = await deriveIdentity(
-				"nuclear anxiety mandate board property fade chief mule west despair photo fiber",
-			);
+		await subject.sync();
+		await subject.addSignature(id, new Signatories.Signatory(new Signatories.MnemonicSignatory(identity2)));
 
-			const id = await subject.signMultiSignature({
-				nonce: "1",
-				signatory: new Signatories.Signatory(new Signatories.MnemonicSignatory(identity1)),
-				data: {
-					publicKeys: [identity1.publicKey, identity2.publicKey, identity3.publicKey],
-					min: 2,
-					senderPublicKey: identity1.publicKey,
+		assert.defined(subject.transaction(id));
+	});
+
+	test("should sign second signature", async () => {
+		const input = {
+			nonce: "1",
+			signatory: new Signatories.Signatory(
+				new Signatories.MnemonicSignatory({
+					signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
+					address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+					publicKey: "publicKey",
+					privateKey: "privateKey",
+				}),
+			),
+			data: {
+				mnemonic: "this is a top secret second mnemonic",
+			},
+		};
+		const id = await subject.signSecondSignature(input);
+
+		assert.string(id);
+		assert.containKey(subject.signed(), id);
+		assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
+	});
+
+	test("should sign multi signature registration", async () => {
+		const identity1 = await deriveIdentity(
+			"upset boat motor few ketchup merge punch gesture lecture piano neutral uniform",
+		);
+		const identity2 = await deriveIdentity(
+			"citizen door athlete item name various drive onion foster audit board myself",
+		);
+		const identity3 = await deriveIdentity(
+			"nuclear anxiety mandate board property fade chief mule west despair photo fiber",
+		);
+
+		const id = await subject.signMultiSignature({
+			nonce: "1",
+			signatory: new Signatories.Signatory(new Signatories.MnemonicSignatory(identity1)),
+			data: {
+				publicKeys: [identity1.publicKey, identity2.publicKey, identity3.publicKey],
+				min: 2,
+				senderPublicKey: identity1.publicKey,
+			},
+		});
+
+		assert.string(id);
+		assert.containKey(subject.waitingForOtherSignatures(), id);
+		assert.instance(subject.waitingForOtherSignatures()[id], ExtendedSignedTransactionData);
+		assert.false(subject.canBeSigned(id));
+	});
+
+	test("should sign ipfs", async () => {
+		const input = {
+			nonce: "1",
+			signatory: new Signatories.Signatory(
+				new Signatories.MnemonicSignatory({
+					signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
+					address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+					publicKey: "publicKey",
+					privateKey: "privateKey",
+				}),
+			),
+			data: {
+				hash: "QmR45FmbVVrixReBwJkhEKde2qwHYaQzGxu4ZoDeswuF9w",
+			},
+		};
+		const id = await subject.signIpfs(input);
+
+		assert.string(id);
+		assert.containKey(subject.signed(), id);
+		assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
+	});
+
+	test("should sign multi payment", async () => {
+		const input = {
+			nonce: "1",
+			signatory: new Signatories.Signatory(
+				new Signatories.MnemonicSignatory({
+					signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
+					address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+					publicKey: "publicKey",
+					privateKey: "privateKey",
+				}),
+			),
+			data: {
+				payments: [
+					{ to: "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9", amount: 10 },
+					{ to: "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9", amount: 10 },
+					{ to: "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9", amount: 10 },
+				],
+			},
+		};
+		const id = await subject.signMultiPayment(input);
+
+		assert.string(id);
+		assert.containKey(subject.signed(), id);
+		assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
+	});
+
+	test("should sign delegate resignation", async () => {
+		const input = {
+			nonce: "1",
+			signatory: new Signatories.Signatory(
+				new Signatories.MnemonicSignatory({
+					signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
+					address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+					publicKey: "publicKey",
+					privateKey: "privateKey",
+				}),
+			),
+		};
+		const id = await subject.signDelegateResignation(input);
+
+		assert.string(id);
+		assert.containKey(subject.signed(), id);
+		assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
+	});
+
+	test("should sign htlc lock", async () => {
+		const input = {
+			nonce: "1",
+			signatory: new Signatories.Signatory(
+				new Signatories.MnemonicSignatory({
+					signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
+					address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+					publicKey: "publicKey",
+					privateKey: "privateKey",
+				}),
+			),
+			data: {
+				amount: 1,
+				to: "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9",
+				secretHash: "0f128d401958b1b30ad0d10406f47f9489321017b4614e6cb993fc63913c5454",
+				expiration: {
+					type: 1,
+					value: 1607523002,
 				},
-			});
+			},
+		};
+		const id = await subject.signHtlcLock(input);
 
-			assert.string(id);
-			assert.containKey(subject.waitingForOtherSignatures(), id);
-			assert.instance(subject.waitingForOtherSignatures()[id], ExtendedSignedTransactionData);
-			assert.false(subject.canBeSigned(id));
-		});
+		assert.string(id);
+		assert.containKey(subject.signed(), id);
+		assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
+	});
 
-		test("should sign ipfs", async () => {
-			const input = {
-				nonce: "1",
-				signatory: new Signatories.Signatory(
-					new Signatories.MnemonicSignatory({
-						signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
-						address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-						publicKey: "publicKey",
-						privateKey: "privateKey",
-					}),
-				),
-				data: {
-					hash: "QmR45FmbVVrixReBwJkhEKde2qwHYaQzGxu4ZoDeswuF9w",
-				},
-			};
-			const id = await subject.signIpfs(input);
+	test("should sign htlc claim", async () => {
+		const input = {
+			nonce: "1",
+			signatory: new Signatories.Signatory(
+				new Signatories.MnemonicSignatory({
+					signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
+					address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+					publicKey: "publicKey",
+					privateKey: "privateKey",
+				}),
+			),
+			data: {
+				lockTransactionId: "943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4",
+				unlockSecret: "c27f1ce845d8c29eebc9006be932b604fd06755521b1a8b0be4204c65377151a",
+			},
+		};
+		const id = await subject.signHtlcClaim(input);
 
-			assert.string(id);
-			assert.containKey(subject.signed(), id);
-			assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
-		});
+		assert.string(id);
+		assert.containKey(subject.signed(), id);
+		assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
+	});
 
-		test("should sign multi payment", async () => {
-			const input = {
-				nonce: "1",
-				signatory: new Signatories.Signatory(
-					new Signatories.MnemonicSignatory({
-						signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
-						address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-						publicKey: "publicKey",
-						privateKey: "privateKey",
-					}),
-				),
-				data: {
-					payments: [
-						{ to: "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9", amount: 10 },
-						{ to: "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9", amount: 10 },
-						{ to: "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9", amount: 10 },
-					],
-				},
-			};
-			const id = await subject.signMultiPayment(input);
+	test("should sign htlc refund", async () => {
+		const input = {
+			nonce: "1",
+			signatory: new Signatories.Signatory(
+				new Signatories.MnemonicSignatory({
+					signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
+					address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+					publicKey: "publicKey",
+					privateKey: "privateKey",
+				}),
+			),
+			data: {
+				lockTransactionId: "943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4",
+			},
+		};
+		const id = await subject.signHtlcRefund(input);
 
-			assert.string(id);
-			assert.containKey(subject.signed(), id);
-			assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
-		});
-
-		test("should sign delegate resignation", async () => {
-			const input = {
-				nonce: "1",
-				signatory: new Signatories.Signatory(
-					new Signatories.MnemonicSignatory({
-						signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
-						address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-						publicKey: "publicKey",
-						privateKey: "privateKey",
-					}),
-				),
-			};
-			const id = await subject.signDelegateResignation(input);
-
-			assert.string(id);
-			assert.containKey(subject.signed(), id);
-			assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
-		});
-
-		test("should sign htlc lock", async () => {
-			const input = {
-				nonce: "1",
-				signatory: new Signatories.Signatory(
-					new Signatories.MnemonicSignatory({
-						signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
-						address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-						publicKey: "publicKey",
-						privateKey: "privateKey",
-					}),
-				),
-				data: {
-					amount: 1,
-					to: "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9",
-					secretHash: "0f128d401958b1b30ad0d10406f47f9489321017b4614e6cb993fc63913c5454",
-					expiration: {
-						type: 1,
-						value: 1607523002,
-					},
-				},
-			};
-			const id = await subject.signHtlcLock(input);
-
-			assert.string(id);
-			assert.containKey(subject.signed(), id);
-			assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
-		});
-
-		test("should sign htlc claim", async () => {
-			const input = {
-				nonce: "1",
-				signatory: new Signatories.Signatory(
-					new Signatories.MnemonicSignatory({
-						signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
-						address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-						publicKey: "publicKey",
-						privateKey: "privateKey",
-					}),
-				),
-				data: {
-					lockTransactionId: "943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4",
-					unlockSecret: "c27f1ce845d8c29eebc9006be932b604fd06755521b1a8b0be4204c65377151a",
-				},
-			};
-			const id = await subject.signHtlcClaim(input);
-
-			assert.string(id);
-			assert.containKey(subject.signed(), id);
-			assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
-		});
-
-		test("should sign htlc refund", async () => {
-			const input = {
-				nonce: "1",
-				signatory: new Signatories.Signatory(
-					new Signatories.MnemonicSignatory({
-						signingKey: "bomb open frame quit success evolve gain donate prison very rent later",
-						address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-						publicKey: "publicKey",
-						privateKey: "privateKey",
-					}),
-				),
-				data: {
-					lockTransactionId: "943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4",
-				},
-			};
-			const id = await subject.signHtlcRefund(input);
-
-			assert.string(id);
-			assert.containKey(subject.signed(), id);
-			assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
-		});
+		assert.string(id);
+		assert.containKey(subject.signed(), id);
+		assert.instance(subject.transaction(id), ExtendedSignedTransactionData);
 	});
 
 	test("#transaction lifecycle", async () => {
@@ -866,7 +862,7 @@ describe("ARK", (suite) => {
 	});
 });
 
-// describe("Shared", () => {
+// describe("Shared", ({ afterEach, beforeEach, test }) => {
 //     it.each([
 //         {
 //             coin: "ARK",

--- a/packages/profiles/source/wallet.factory.test.js
+++ b/packages/profiles/source/wallet.factory.test.js
@@ -69,170 +69,150 @@ test.before.each(async () => {
 		.persist();
 });
 
-describe("#fromMnemonicWithBIP39", () => {
-	test("should create a wallet using BIP39", async () => {
-		const wallet = await subject.fromMnemonicWithBIP39({
-			coin: "ARK",
-			network: "ark.devnet",
-			mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
-		});
-
-		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
-		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
+test("#fromMnemonicWithBIP39 - should create a wallet using BIP39", async () => {
+	const wallet = await subject.fromMnemonicWithBIP39({
+		coin: "ARK",
+		network: "ark.devnet",
+		mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
 	});
 
-	test("should throw if BIP39 is requested but extended public keys are used", async () => {
-		await assert.rejects(
-			() =>
-				subject.fromMnemonicWithBIP39({
-					coin: "ADA",
-					network: "ada.testnet",
-					mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
-				}),
-			"The configured network uses extended public keys with BIP44 for derivation.",
-		);
-	});
-
-	test("should create a wallet using BIP39 with encryption", async () => {
-		const wallet = await subject.fromMnemonicWithBIP39({
-			coin: "ARK",
-			network: "ark.devnet",
-			mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
-			password: "password",
-		});
-
-		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
-		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
-		assert.string(wallet.data().get(WalletData.EncryptedSigningKey));
-
-		assert.is(
-			PBKDF2.decrypt(wallet.data().get(WalletData.EncryptedSigningKey), "password"),
-			"bomb open frame quit success evolve gain donate prison very rent later",
-		);
-	});
+	assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
+	assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
 });
 
-describe("#fromMnemonicWithBIP44", () => {
-	describe("should create a wallet using BIP44 (mnemonic > address)", () => {
-		test("should work for ADA", async () => {
-			const wallet = await subject.fromMnemonicWithBIP44({
+test("#fromMnemonicWithBIP39 - should throw if BIP39 is requested but extended public keys are used", async () => {
+	await assert.rejects(
+		() =>
+			subject.fromMnemonicWithBIP39({
 				coin: "ADA",
 				network: "ada.testnet",
-				mnemonic:
-					"excess behave track soul table wear ocean cash stay nature item turtle palm soccer lunch horror start stumble month panic right must lock dress",
-				levels: { account: 0 },
-			});
-
-			assert.is(
-				wallet.address(),
-				"addr_test1qqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmn8k8ttq8f3gag0h89aepvx3xf69g0l9pf80tqv7cve0l33sw96paj",
-			);
-		});
-
-		test("should work for BTC", async () => {
-			const wallet = await subject.fromMnemonicWithBIP44({
-				coin: "BTC",
-				network: "btc.testnet",
 				mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
-				levels: { account: 0 },
-			});
-
-			assert.is(wallet.address(), "n16aeukbAKUZPh3iefK3DjpyJAc6TUHw9C");
-		});
-	});
-
-	describe("should create a wallet using BIP44 (mnemonic > extended public key)", () => {
-		test("should work for ADA", async () => {
-			const wallet = await subject.fromMnemonicWithBIP44({
-				coin: "ADA",
-				network: "ada.testnet",
-				mnemonic:
-					"excess behave track soul table wear ocean cash stay nature item turtle palm soccer lunch horror start stumble month panic right must lock dress",
-				levels: { account: 0 },
-			});
-
-			assert.is(
-				wallet.publicKey(),
-				"xpub14mpsxvx74mxaw5p3jksdwvp9d7h0sup8qg43hhd8eg9xr09q540y64667k5nhh6fqk3hqtadah69r6jcg7gayvadayykt4sghtzhxpqca4vve",
-			);
-		});
-
-		test("should work for BTC", async () => {
-			const wallet = await subject.fromMnemonicWithBIP44({
-				coin: "BTC",
-				network: "btc.testnet",
-				mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
-				levels: { account: 0 },
-			});
-
-			assert.is(
-				wallet.publicKey(),
-				"tpubDDdFbnZcaQhDWfstrSh8cWxcSFzJZfeteebCDwXUeis9JuvajhA4qwjhoDN8Em3gKX1t1A8FcVNMNWPPUMAmWKLtneA2cj4kci1boqmKf4m",
-			);
-		});
-	});
+			}),
+		"The configured network uses extended public keys with BIP44 for derivation.",
+	);
 });
 
-describe("#fromMnemonicWithBIP49", () => {
-	describe("should create a wallet using BIP49 (mnemonic > address)", () => {
-		test("for BTC", async () => {
-			const wallet = await subject.fromMnemonicWithBIP49({
-				coin: "BTC",
-				network: "btc.testnet",
-				mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
-				levels: { account: 0 },
-			});
-
-			assert.is(wallet.address(), "2NDqSnogr4eQeLrPWM5GmgBvNuMbwdyh1Bi");
-		});
+test("#fromMnemonicWithBIP39 - should create a wallet using BIP39 with encryption", async () => {
+	const wallet = await subject.fromMnemonicWithBIP39({
+		coin: "ARK",
+		network: "ark.devnet",
+		mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
+		password: "password",
 	});
 
-	describe("should create a wallet using BIP49 (mnemonic > extended public key)", () => {
-		test("for BTC", async () => {
-			const wallet = await subject.fromMnemonicWithBIP49({
-				coin: "BTC",
-				network: "btc.testnet",
-				mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
-				levels: { account: 0 },
-			});
+	assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
+	assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
+	assert.string(wallet.data().get(WalletData.EncryptedSigningKey));
 
-			assert.is(
-				wallet.publicKey(),
-				"tpubDDtBpveGs7uW1X715ZzEHtH1KinDUTW71E3u1ourxCameEdmWrQMLdFGAAYmgTWbLxWw8Dcb6PAV37eNCZDSUu3s2uc2ZTvXRodnUcTLJ8u",
-			);
-		});
-	});
+	assert.is(
+		PBKDF2.decrypt(wallet.data().get(WalletData.EncryptedSigningKey), "password"),
+		"bomb open frame quit success evolve gain donate prison very rent later",
+	);
 });
 
-describe("#fromMnemonicWithBIP84", () => {
-	describe("should create a wallet using BIP84 (mnemonic > address)", () => {
-		test("for BTC", async () => {
-			const wallet = await subject.fromMnemonicWithBIP84({
-				coin: "BTC",
-				network: "btc.testnet",
-				mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
-				levels: { account: 0 },
-			});
-
-			assert.is(wallet.address(), "tb1quhtzwu2pm7apf4r0c4sgj73cvdrspy6ez4jxjn");
-		});
+test("#fromMnemonicWithBIP44 - should create a wallet using BIP44 (mnemonic > address) for ADA", async () => {
+	const wallet = await subject.fromMnemonicWithBIP44({
+		coin: "ADA",
+		network: "ada.testnet",
+		mnemonic:
+			"excess behave track soul table wear ocean cash stay nature item turtle palm soccer lunch horror start stumble month panic right must lock dress",
+		levels: { account: 0 },
 	});
 
-	describe("should create a wallet using BIP84 (mnemonic > extended public key)", () => {
-		test("for BTC", async () => {
-			const wallet = await subject.fromMnemonicWithBIP84({
-				coin: "BTC",
-				network: "btc.testnet",
-				mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
-				levels: { account: 0 },
-			});
+	assert.is(
+		wallet.address(),
+		"addr_test1qqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmn8k8ttq8f3gag0h89aepvx3xf69g0l9pf80tqv7cve0l33sw96paj",
+	);
+});
 
-			assert.is(
-				wallet.publicKey(),
-				"tpubDDVt9raAkiwRY7hvDoYYP3aAJMVc6rUN4sAEPFHUamgpupZKQAFZeBJ9S83UksWoGUTqseKEuwerpgqPytYuhSxXMKVYz7tFMinkt5iGk4g",
-			);
-		});
+test("#fromMnemonicWithBIP44 - should create a wallet using BIP44 (mnemonic > address) for BTC", async () => {
+	const wallet = await subject.fromMnemonicWithBIP44({
+		coin: "BTC",
+		network: "btc.testnet",
+		mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
+		levels: { account: 0 },
 	});
+
+	assert.is(wallet.address(), "n16aeukbAKUZPh3iefK3DjpyJAc6TUHw9C");
+});
+
+test("#fromMnemonicWithBIP44 - should create a wallet using BIP44 (mnemonic > extended public key) for ADA", async () => {
+	const wallet = await subject.fromMnemonicWithBIP44({
+		coin: "ADA",
+		network: "ada.testnet",
+		mnemonic:
+			"excess behave track soul table wear ocean cash stay nature item turtle palm soccer lunch horror start stumble month panic right must lock dress",
+		levels: { account: 0 },
+	});
+
+	assert.is(
+		wallet.publicKey(),
+		"xpub14mpsxvx74mxaw5p3jksdwvp9d7h0sup8qg43hhd8eg9xr09q540y64667k5nhh6fqk3hqtadah69r6jcg7gayvadayykt4sghtzhxpqca4vve",
+	);
+});
+
+test("#fromMnemonicWithBIP44 - should create a wallet using BIP44 (mnemonic > extended public key) for BTC", async () => {
+	const wallet = await subject.fromMnemonicWithBIP44({
+		coin: "BTC",
+		network: "btc.testnet",
+		mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
+		levels: { account: 0 },
+	});
+
+	assert.is(
+		wallet.publicKey(),
+		"tpubDDdFbnZcaQhDWfstrSh8cWxcSFzJZfeteebCDwXUeis9JuvajhA4qwjhoDN8Em3gKX1t1A8FcVNMNWPPUMAmWKLtneA2cj4kci1boqmKf4m",
+	);
+});
+
+test("#fromMnemonicWithBIP49 - should create a wallet using BIP49 (mnemonic > address) for BTC", async () => {
+	const wallet = await subject.fromMnemonicWithBIP49({
+		coin: "BTC",
+		network: "btc.testnet",
+		mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
+		levels: { account: 0 },
+	});
+
+	assert.is(wallet.address(), "2NDqSnogr4eQeLrPWM5GmgBvNuMbwdyh1Bi");
+});
+
+test("#fromMnemonicWithBIP49 - should create a wallet using BIP49 (mnemonic > extended public key) for BTC", async () => {
+	const wallet = await subject.fromMnemonicWithBIP49({
+		coin: "BTC",
+		network: "btc.testnet",
+		mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
+		levels: { account: 0 },
+	});
+
+	assert.is(
+		wallet.publicKey(),
+		"tpubDDtBpveGs7uW1X715ZzEHtH1KinDUTW71E3u1ourxCameEdmWrQMLdFGAAYmgTWbLxWw8Dcb6PAV37eNCZDSUu3s2uc2ZTvXRodnUcTLJ8u",
+	);
+});
+
+test("#fromMnemonicWithBIP84 - should create a wallet using BIP84 (mnemonic > address) for BTC", async () => {
+	const wallet = await subject.fromMnemonicWithBIP84({
+		coin: "BTC",
+		network: "btc.testnet",
+		mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
+		levels: { account: 0 },
+	});
+
+	assert.is(wallet.address(), "tb1quhtzwu2pm7apf4r0c4sgj73cvdrspy6ez4jxjn");
+});
+
+test("#fromMnemonicWithBIP84 - should create a wallet using BIP84 (mnemonic > extended public key) for BTC", async () => {
+	const wallet = await subject.fromMnemonicWithBIP84({
+		coin: "BTC",
+		network: "btc.testnet",
+		mnemonic: "bomb open frame quit success evolve gain donate prison very rent later",
+		levels: { account: 0 },
+	});
+
+	assert.is(
+		wallet.publicKey(),
+		"tpubDDVt9raAkiwRY7hvDoYYP3aAJMVc6rUN4sAEPFHUamgpupZKQAFZeBJ9S83UksWoGUTqseKEuwerpgqPytYuhSxXMKVYz7tFMinkt5iGk4g",
+	);
 });
 
 test("#fromAddress", async () => {
@@ -254,49 +234,47 @@ test("#fromAddress", async () => {
 	assert.is(mainnetWallet.address(), "AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX");
 });
 
-describe("#fromPublicKey", () => {
-	test("for ARK", async () => {
-		const wallet = await subject.fromPublicKey({
-			coin: "ARK",
-			network: "ark.devnet",
-			publicKey: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
-		});
-
-		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
-		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
+test("#fromPublicKey - for ARK", async () => {
+	const wallet = await subject.fromPublicKey({
+		coin: "ARK",
+		network: "ark.devnet",
+		publicKey: "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd",
 	});
 
-	test("for BTC (testnet)", async () => {
-		const wallet = await subject.fromPublicKey({
-			coin: "BTC",
-			network: "btc.testnet",
-			publicKey:
-				"tpubDCdFvjrda9JXDYFb518YfcEEWSj3gRfRAU69PGnNS4dYx3bBARVhKQNRC1wBYComzGCyXea7rpYW2YjxahrEPzapLQpfSMky4bdz3YPTgTJ",
-			bip44: { account: 0 },
-		});
+	assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
+	assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
+});
 
-		assert.is(wallet.address(), "mp2Ucb5WLX5v3aD3wmwbTi5xsbLESKhQDf");
-		assert.is(
-			wallet.publicKey(),
+test("#fromPublicKey - for BTC (testnet)", async () => {
+	const wallet = await subject.fromPublicKey({
+		coin: "BTC",
+		network: "btc.testnet",
+		publicKey:
 			"tpubDCdFvjrda9JXDYFb518YfcEEWSj3gRfRAU69PGnNS4dYx3bBARVhKQNRC1wBYComzGCyXea7rpYW2YjxahrEPzapLQpfSMky4bdz3YPTgTJ",
-		);
+		bip44: { account: 0 },
 	});
 
-	test("for BTC (livenet)", async () => {
-		const wallet = await subject.fromPublicKey({
-			coin: "BTC",
-			network: "btc.livenet",
-			publicKey:
-				"xpub6Bk8X5Y1FN7pSecqoqkHe8F8gNaqMVApCrmMxZnRvSw4JpgqeM5T83Ze6uD4XEMiCSwZiwysnny8uQj5F6XAPF9FNKYNHTMoAu97bDXNtRe",
-			bip44: { account: 0 },
-		});
+	assert.is(wallet.address(), "mp2Ucb5WLX5v3aD3wmwbTi5xsbLESKhQDf");
+	assert.is(
+		wallet.publicKey(),
+		"tpubDCdFvjrda9JXDYFb518YfcEEWSj3gRfRAU69PGnNS4dYx3bBARVhKQNRC1wBYComzGCyXea7rpYW2YjxahrEPzapLQpfSMky4bdz3YPTgTJ",
+	);
+});
 
-		assert.is(wallet.address(), "12KRAVpawWmzWNnv9WbqqKRHuhs7nFiQro");
-		assert.is(
-			wallet.publicKey(),
+test("#fromPublicKey - for BTC (livenet)", async () => {
+	const wallet = await subject.fromPublicKey({
+		coin: "BTC",
+		network: "btc.livenet",
+		publicKey:
 			"xpub6Bk8X5Y1FN7pSecqoqkHe8F8gNaqMVApCrmMxZnRvSw4JpgqeM5T83Ze6uD4XEMiCSwZiwysnny8uQj5F6XAPF9FNKYNHTMoAu97bDXNtRe",
-		);
+		bip44: { account: 0 },
 	});
+
+	assert.is(wallet.address(), "12KRAVpawWmzWNnv9WbqqKRHuhs7nFiQro");
+	assert.is(
+		wallet.publicKey(),
+		"xpub6Bk8X5Y1FN7pSecqoqkHe8F8gNaqMVApCrmMxZnRvSw4JpgqeM5T83Ze6uD4XEMiCSwZiwysnny8uQj5F6XAPF9FNKYNHTMoAu97bDXNtRe",
+	);
 });
 
 test("#fromPrivateKey", async () => {
@@ -322,31 +300,29 @@ test("#fromAddressWithDerivationPath", async () => {
 	assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
 });
 
-describe("#fromWIF", () => {
-	test("should create it with a WIF", async () => {
-		const wallet = await subject.fromWIF({
-			coin: "ARK",
-			network: "ark.devnet",
-			wif: "SHA89yQdW3bLFYyCvEBpn7ngYNR8TEojGCC1uAJjT5esJPm1NiG3",
-		});
-
-		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
-		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
+test("#fromWIF - should create it with a WIF", async () => {
+	const wallet = await subject.fromWIF({
+		coin: "ARK",
+		network: "ark.devnet",
+		wif: "SHA89yQdW3bLFYyCvEBpn7ngYNR8TEojGCC1uAJjT5esJPm1NiG3",
 	});
 
-	test("should create it with a WIF and encryption", async () => {
-		const { compressed, privateKey } = decode("SHA89yQdW3bLFYyCvEBpn7ngYNR8TEojGCC1uAJjT5esJPm1NiG3");
+	assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
+	assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
+});
 
-		const wallet = await subject.fromWIF({
-			coin: "ARK",
-			network: "ark.devnet",
-			wif: encrypt(privateKey, compressed, "password"),
-			password: "password",
-		});
+test("#fromWIF - should create it with a WIF and encryption", async () => {
+	const { compressed, privateKey } = decode("SHA89yQdW3bLFYyCvEBpn7ngYNR8TEojGCC1uAJjT5esJPm1NiG3");
 
-		assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
-		assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
+	const wallet = await subject.fromWIF({
+		coin: "ARK",
+		network: "ark.devnet",
+		wif: encrypt(privateKey, compressed, "password"),
+		password: "password",
 	});
+
+	assert.is(wallet.address(), "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW");
+	assert.is(wallet.publicKey(), "030fde54605c5d53436217a2849d276376d0b0f12c71219cd62b0a4539e1e75acd");
 });
 
 test.run();

--- a/packages/profiles/source/wallet.identifier.factory.test.js
+++ b/packages/profiles/source/wallet.identifier.factory.test.js
@@ -65,67 +65,63 @@ test("should create wallet identifier for address", async () => {
 	});
 });
 
-describe("should create wallet identifier with mnenonic", () => {
-	test("should work", async () => {
-		const wallet = await profile.walletFactory().fromMnemonicWithBIP39({
-			coin: "ARK",
-			network: "ark.devnet",
-			mnemonic: identity.mnemonic,
-		});
-
-		assert.equal(await WalletIdentifierFactory.make(wallet), {
-			type: "address",
-			value: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-			method: "bip39",
-		});
+test("should create wallet identifier with mnenonic", async () => {
+	const wallet = await profile.walletFactory().fromMnemonicWithBIP39({
+		coin: "ARK",
+		network: "ark.devnet",
+		mnemonic: identity.mnemonic,
 	});
 
-	test("should work for network that uses extended public key", async () => {
-		const wallet = await profile.walletFactory().fromMnemonicWithBIP44({
-			coin: "BTC",
-			network: "btc.livenet",
-			mnemonic: identity.mnemonic,
-			levels: { account: 0 },
-		});
-
-		assert.equal(await WalletIdentifierFactory.make(wallet), {
-			type: "extendedPublicKey",
-			value: "xpub6CVZnKBTDKtVdkizs2fwFrb5WDjsc4MzCqmFSHEU1jYvuugQaQBzVzF5A7E9AVr793Lj5KPtFdyNcmA42RtFeko8JDZ2nUpciHRQFMGdcvM",
-			method: "bip44",
-		});
+	assert.equal(await WalletIdentifierFactory.make(wallet), {
+		type: "address",
+		value: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+		method: "bip39",
 	});
 });
 
-describe("should create wallet identifier with mnenonic with password", () => {
-	test("should work", async () => {
-		const wallet = await profile.walletFactory().fromMnemonicWithBIP39({
-			coin: "ARK",
-			network: "ark.devnet",
-			mnemonic: identity.mnemonic,
-			password: "password",
-		});
-
-		assert.equal(await WalletIdentifierFactory.make(wallet), {
-			type: "address",
-			value: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-			method: "bip39",
-		});
+test("should create wallet identifier with mnenonic for network that uses extended public key", async () => {
+	const wallet = await profile.walletFactory().fromMnemonicWithBIP44({
+		coin: "BTC",
+		network: "btc.livenet",
+		mnemonic: identity.mnemonic,
+		levels: { account: 0 },
 	});
 
-	test("should work for network that uses extended public key", async () => {
-		const wallet = await profile.walletFactory().fromMnemonicWithBIP44({
-			coin: "BTC",
-			network: "btc.livenet",
-			mnemonic: identity.mnemonic,
-			password: "password",
-			levels: { account: 0 },
-		});
+	assert.equal(await WalletIdentifierFactory.make(wallet), {
+		type: "extendedPublicKey",
+		value: "xpub6CVZnKBTDKtVdkizs2fwFrb5WDjsc4MzCqmFSHEU1jYvuugQaQBzVzF5A7E9AVr793Lj5KPtFdyNcmA42RtFeko8JDZ2nUpciHRQFMGdcvM",
+		method: "bip44",
+	});
+});
 
-		assert.equal(await WalletIdentifierFactory.make(wallet), {
-			type: "extendedPublicKey",
-			value: "xpub6CVZnKBTDKtVdkizs2fwFrb5WDjsc4MzCqmFSHEU1jYvuugQaQBzVzF5A7E9AVr793Lj5KPtFdyNcmA42RtFeko8JDZ2nUpciHRQFMGdcvM",
-			method: "bip44",
-		});
+test("should create wallet identifier with mnenonic with password", async () => {
+	const wallet = await profile.walletFactory().fromMnemonicWithBIP39({
+		coin: "ARK",
+		network: "ark.devnet",
+		mnemonic: identity.mnemonic,
+		password: "password",
+	});
+
+	assert.equal(await WalletIdentifierFactory.make(wallet), {
+		type: "address",
+		value: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+		method: "bip39",
+	});
+});
+
+test("should create wallet identifier with mnenonic with password for network that uses extended public key", async () => {
+	const wallet = await profile.walletFactory().fromMnemonicWithBIP44({
+		coin: "BTC",
+		network: "btc.livenet",
+		mnemonic: identity.mnemonic,
+		password: "password",
+		levels: { account: 0 },
+	});
+
+	assert.equal(await WalletIdentifierFactory.make(wallet), {
+		type: "extendedPublicKey",
+		value: "xpub6CVZnKBTDKtVdkizs2fwFrb5WDjsc4MzCqmFSHEU1jYvuugQaQBzVzF5A7E9AVr793Lj5KPtFdyNcmA42RtFeko8JDZ2nUpciHRQFMGdcvM",
+		method: "bip44",
 	});
 });
 

--- a/packages/profiles/source/wallet.mutator.test.js
+++ b/packages/profiles/source/wallet.mutator.test.js
@@ -85,7 +85,7 @@ test.before.each(async () => {
 
 test.before(() => nock.disableNetConnect());
 
-describe("#setCoin", () => {
+describe("#setCoin", ({ afterEach, beforeEach, test }) => {
 	test("should mark the wallet as partially restored if the coin construction fails", async () => {
 		subject = new Wallet(UUID.random(), {}, profile);
 
@@ -103,7 +103,7 @@ describe("#setCoin", () => {
 	});
 });
 
-// describe("#identity", () => {
+// describe("#identity", ({ afterEach, beforeEach, test }) => {
 // 	it.each(["bip39", "bip44", "bip49", "bip84"])("should mutate the address with a path (%s)", async (type) => {
 // 		subject.data().set(WalletData.ImportMethod, WalletImportMethod.Address);
 
@@ -151,126 +151,122 @@ describe("#setCoin", () => {
 // 	);
 // });
 
-describe("#address", () => {
-	test("should mutate the address with a path", async () => {
-		subject.data().set(WalletData.ImportMethod, WalletImportMethod.Address);
+test("should mutate the address with a path", async () => {
+	subject.data().set(WalletData.ImportMethod, WalletImportMethod.Address);
 
-		assert.false(subject.data().has(WalletData.DerivationType));
-		assert.false(subject.data().has(WalletData.DerivationPath));
+	assert.false(subject.data().has(WalletData.DerivationType));
+	assert.false(subject.data().has(WalletData.DerivationPath));
 
-		await subject.mutator().address({
-			address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-			path: "path",
-			type: "bip39",
-		});
-
-		assert.true(subject.data().has(WalletData.DerivationType));
-		assert.true(subject.data().has(WalletData.DerivationPath));
+	await subject.mutator().address({
+		address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+		path: "path",
+		type: "bip39",
 	});
+
+	assert.true(subject.data().has(WalletData.DerivationType));
+	assert.true(subject.data().has(WalletData.DerivationPath));
 });
 
-describe("#removeEncryption", () => {
-	test("should remove the encryption password of a wallet imported by mnemonic", async () => {
-		subject.data().set(WalletData.ImportMethod, WalletImportMethod.BIP39.MNEMONIC_WITH_ENCRYPTION);
+test("#removeEncryption - should remove the encryption password of a wallet imported by mnemonic", async () => {
+	subject.data().set(WalletData.ImportMethod, WalletImportMethod.BIP39.MNEMONIC_WITH_ENCRYPTION);
 
-		subject.signingKey().set(identity.mnemonic, "password");
+	subject.signingKey().set(identity.mnemonic, "password");
 
-		const address = (await subject.coin().address().fromMnemonic(identity.mnemonic)).address;
+	const address = (await subject.coin().address().fromMnemonic(identity.mnemonic)).address;
 
-		mockery(subject, "address").mockReturnValueOnce(address);
-		mockery(subject, "isSecondSignature").mockReturnValueOnce(false);
+	mockery(subject, "address").mockReturnValueOnce(address);
+	mockery(subject, "isSecondSignature").mockReturnValueOnce(false);
 
-		assert.true(subject.signingKey().exists());
+	assert.true(subject.signingKey().exists());
 
-		await subject.mutator().removeEncryption("password");
+	await subject.mutator().removeEncryption("password");
 
-		assert.false(subject.signingKey().exists());
+	assert.false(subject.signingKey().exists());
 
-		assert.is(subject.data().get(WalletData.ImportMethod), WalletImportMethod.BIP39.MNEMONIC);
-	});
+	assert.is(subject.data().get(WalletData.ImportMethod), WalletImportMethod.BIP39.MNEMONIC);
+});
 
-	test("should remove the encryption password of a wallet imported by mnemonic with second signature", async () => {
-		subject.data().set(WalletData.ImportMethod, WalletImportMethod.BIP39.MNEMONIC_WITH_ENCRYPTION);
+test("#removeEncryption - should remove the encryption password of a wallet imported by mnemonic with second signature", async () => {
+	subject.data().set(WalletData.ImportMethod, WalletImportMethod.BIP39.MNEMONIC_WITH_ENCRYPTION);
 
-		subject.signingKey().set(identity.mnemonic, "password");
-		subject.confirmKey().set(identity.secondMnemonic, "password");
+	subject.signingKey().set(identity.mnemonic, "password");
+	subject.confirmKey().set(identity.secondMnemonic, "password");
 
-		const address = (await subject.coin().address().fromMnemonic(identity.mnemonic)).address;
+	const address = (await subject.coin().address().fromMnemonic(identity.mnemonic)).address;
 
-		mockery(subject, "address").mockReturnValueOnce(address);
-		mockery(subject, "isSecondSignature").mockReturnValueOnce(true);
+	mockery(subject, "address").mockReturnValueOnce(address);
+	mockery(subject, "isSecondSignature").mockReturnValueOnce(true);
 
-		assert.true(subject.signingKey().exists());
-		assert.true(subject.confirmKey().exists());
+	assert.true(subject.signingKey().exists());
+	assert.true(subject.confirmKey().exists());
 
-		await subject.mutator().removeEncryption("password");
+	await subject.mutator().removeEncryption("password");
 
-		assert.false(subject.signingKey().exists());
-		assert.false(subject.confirmKey().exists());
+	assert.false(subject.signingKey().exists());
+	assert.false(subject.confirmKey().exists());
 
-		assert.is(subject.data().get(WalletData.ImportMethod), WalletImportMethod.BIP39.MNEMONIC);
-	});
+	assert.is(subject.data().get(WalletData.ImportMethod), WalletImportMethod.BIP39.MNEMONIC);
+});
 
-	test("should remove the encryption password of a wallet imported by secret", async () => {
-		subject.data().set(WalletData.ImportMethod, WalletImportMethod.SECRET_WITH_ENCRYPTION);
+test("#removeEncryption - should remove the encryption password of a wallet imported by secret", async () => {
+	subject.data().set(WalletData.ImportMethod, WalletImportMethod.SECRET_WITH_ENCRYPTION);
 
-		subject.signingKey().set("secret", "password");
+	subject.signingKey().set("secret", "password");
 
-		const address = (await subject.coin().address().fromSecret("secret")).address;
+	const address = (await subject.coin().address().fromSecret("secret")).address;
 
-		mockery(subject, "address").mockReturnValueOnce(address);
-		mockery(subject, "isSecondSignature").mockReturnValueOnce(false);
+	mockery(subject, "address").mockReturnValueOnce(address);
+	mockery(subject, "isSecondSignature").mockReturnValueOnce(false);
 
-		assert.true(subject.signingKey().exists());
+	assert.true(subject.signingKey().exists());
 
-		await subject.mutator().removeEncryption("password");
+	await subject.mutator().removeEncryption("password");
 
-		assert.false(subject.signingKey().exists());
+	assert.false(subject.signingKey().exists());
 
-		assert.is(subject.data().get(WalletData.ImportMethod), WalletImportMethod.SECRET);
-	});
+	assert.is(subject.data().get(WalletData.ImportMethod), WalletImportMethod.SECRET);
+});
 
-	test("should remove the encryption password of a wallet imported by secret with second signature", async () => {
-		subject.data().set(WalletData.ImportMethod, WalletImportMethod.SECRET_WITH_ENCRYPTION);
+test("#removeEncryption - should remove the encryption password of a wallet imported by secret with second signature", async () => {
+	subject.data().set(WalletData.ImportMethod, WalletImportMethod.SECRET_WITH_ENCRYPTION);
 
-		subject.signingKey().set("secret", "password");
-		subject.confirmKey().set("second-secret", "password");
+	subject.signingKey().set("secret", "password");
+	subject.confirmKey().set("second-secret", "password");
 
-		const address = (await subject.coin().address().fromSecret("secret")).address;
+	const address = (await subject.coin().address().fromSecret("secret")).address;
 
-		mockery(subject, "address").mockReturnValueOnce(address);
-		mockery(subject, "isSecondSignature").mockReturnValueOnce(true);
+	mockery(subject, "address").mockReturnValueOnce(address);
+	mockery(subject, "isSecondSignature").mockReturnValueOnce(true);
 
-		assert.true(subject.signingKey().exists());
-		assert.true(subject.confirmKey().exists());
+	assert.true(subject.signingKey().exists());
+	assert.true(subject.confirmKey().exists());
 
-		await subject.mutator().removeEncryption("password");
+	await subject.mutator().removeEncryption("password");
 
-		assert.false(subject.signingKey().exists());
-		assert.false(subject.confirmKey().exists());
+	assert.false(subject.signingKey().exists());
+	assert.false(subject.confirmKey().exists());
 
-		assert.is(subject.data().get(WalletData.ImportMethod), WalletImportMethod.SECRET);
-	});
+	assert.is(subject.data().get(WalletData.ImportMethod), WalletImportMethod.SECRET);
+});
 
-	test("should throw if the wallet has an unsupported import method", async () => {
-		subject.data().set(WalletData.ImportMethod, WalletImportMethod.Address);
+test("#removeEncryption - should throw if the wallet has an unsupported import method", async () => {
+	subject.data().set(WalletData.ImportMethod, WalletImportMethod.Address);
 
-		await assert.rejects(
-			() => subject.mutator().removeEncryption("wrong-password"),
-			`Import method [${WalletImportMethod.Address}] is not supported.`,
-		);
-	});
+	await assert.rejects(
+		() => subject.mutator().removeEncryption("wrong-password"),
+		`Import method [${WalletImportMethod.Address}] is not supported.`,
+	);
+});
 
-	test("should throw if the provided password does not match the wallet", async () => {
-		subject.signingKey().set(identity.mnemonic, "password");
+test("#removeEncryption - should throw if the provided password does not match the wallet", async () => {
+	subject.signingKey().set(identity.mnemonic, "password");
 
-		subject.data().set(WalletData.ImportMethod, WalletImportMethod.BIP39.MNEMONIC_WITH_ENCRYPTION);
+	subject.data().set(WalletData.ImportMethod, WalletImportMethod.BIP39.MNEMONIC_WITH_ENCRYPTION);
 
-		await assert.rejects(
-			() => subject.mutator().removeEncryption("wrong-password"),
-			"The provided password does not match the wallet.",
-		);
-	});
+	await assert.rejects(
+		() => subject.mutator().removeEncryption("wrong-password"),
+		"The provided password does not match the wallet.",
+	);
 });
 
 test.run();

--- a/packages/profiles/source/wallet.repository.test.js
+++ b/packages/profiles/source/wallet.repository.test.js
@@ -200,12 +200,12 @@ test("#update", async () => {
 	);
 });
 
-// describe("#fill", (suite) => {
-// 	suite.before.each(async () => {
+// describe("#fill", ({ afterEach, beforeEach, test }) => {
+// 	beforeEach(async () => {
 // 		await createEnv();
 // 	});
 
-// 	suite("should fill the wallet", async () => {
+// 	test("should fill the wallet", async () => {
 // 		const profile = new Profile({ avatar: "avatar", data: "", id: "profile-id", name: "name" });
 // 		profile.settings().set(ProfileSetting.Name, "John Doe");
 
@@ -228,7 +228,7 @@ test("#update", async () => {
 // 		assert.equal(subject.findById(newWallet.id()), newWallet);
 // 	});
 
-// 	suite("should fail to fill the wallet if the coin doesn't exist", async () => {
+// 	test("should fail to fill the wallet if the coin doesn't exist", async () => {
 // 		const profile = new Profile({ avatar: "avatar", data: "", id: "profile-id", name: "name" });
 // 		profile.settings().set(ProfileSetting.Name, "John Doe");
 
@@ -254,7 +254,7 @@ test("#update", async () => {
 // 		assert.true(subject.findById(newWallet.id()).isMissingNetwork());
 // 	});
 
-// 	suite("should fail to fill the wallet if the network doesn't exist", async () => {
+// 	test("should fail to fill the wallet if the network doesn't exist", async () => {
 // 		const profile = new Profile({ avatar: "avatar", data: "", id: "profile-id", name: "name" });
 // 		profile.settings().set(ProfileSetting.Name, "John Doe");
 
@@ -281,12 +281,12 @@ test("#update", async () => {
 // 	});
 // });
 
-// describe("#sortBy", (suite) => {
+// describe("#sortBy", ({ afterEach, beforeEach, test }) => {
 // 	let walletARK;
 // 	let walletBTC;
 // 	let walletLSK;
 
-// 	suite.before.each(async () => {
+// 	beforeEach(async () => {
 // 		await createEnv();
 
 // 		subject.flush();
@@ -311,7 +311,7 @@ test("#update", async () => {
 // 		);
 // 	});
 
-// 	suite("should sort by coin", async () => {
+// 	test("should sort by coin", async () => {
 // 		const wallets = subject.sortBy("coin");
 
 // 		assert.is(wallets[0].address(), walletBTC.address()); // BTC
@@ -319,7 +319,7 @@ test("#update", async () => {
 // 		assert.is(wallets[2].address(), walletLSK.address()); // LSK
 // 	});
 
-// 	suite("should sort by coin desc", async () => {
+// 	test("should sort by coin desc", async () => {
 // 		const wallets = subject.sortBy("coin", "desc");
 
 // 		assert.is(wallets[0].address(), walletLSK.address()); // LSK
@@ -327,7 +327,7 @@ test("#update", async () => {
 // 		assert.is(wallets[2].address(), walletBTC.address()); // BTC
 // 	});
 
-// 	suite("should sort by address", async () => {
+// 	test("should sort by address", async () => {
 // 		const wallets = subject.sortBy("address");
 
 // 		assert.is(wallets[0].address(), walletARK.address());
@@ -335,7 +335,7 @@ test("#update", async () => {
 // 		assert.is(wallets[2].address(), walletBTC.address());
 // 	});
 
-// 	suite("should sort by type", async () => {
+// 	test("should sort by type", async () => {
 // 		walletARK.toggleStarred();
 // 		walletLSK.toggleStarred();
 
@@ -346,7 +346,7 @@ test("#update", async () => {
 // 		assert.is(wallets[2].address(), walletLSK.address());
 // 	});
 
-// 	suite("should sort by balance", async () => {
+// 	test("should sort by balance", async () => {
 // 		const wallets = subject.sortBy("balance");
 
 // 		assert.is(wallets[0].address(), walletARK.address());
@@ -354,18 +354,18 @@ test("#update", async () => {
 // 		assert.is(wallets[2].address(), walletLSK.address());
 // 	});
 
-// 	suite("should export toObject", async () => {
+// 	test("should export toObject", async () => {
 // 		const wallets = subject.toObject();
 
 // 		assert.instance(wallets, Object);
 // 	});
 // });
 
-// describe("restore", function (suite) {
+// describe("restore", function ({ afterEach, beforeEach, test }) {
 // 	let profile;
 // 	let wallet;
 
-// 	suite.before.each(async () => {
+// 	beforeEach(async () => {
 // 		await createEnv();
 
 // 		profile = new Profile({ avatar: "avatar", data: "", id: "profile-id", name: "name" });
@@ -386,7 +386,7 @@ test("#update", async () => {
 // 		});
 // 	});
 
-// 	suite("should restore", async () => {
+// 	test("should restore", async () => {
 // 		const newWallet2 = await profile.walletFactory().fromMnemonicWithBIP39({
 // 			coin: "ARK",
 // 			mnemonic: "obvious office stock bind patient jazz off neutral figure truth start limb",
@@ -412,7 +412,7 @@ test("#update", async () => {
 // 		assert.true(subject.findById(newWallet2.id()).hasBeenFullyRestored());
 // 	});
 
-// 	suite("should do nothing if the wallet has already been fully restored", async () => {
+// 	test("should do nothing if the wallet has already been fully restored", async () => {
 // 		subject.findById(wallet.id()).markAsFullyRestored();
 
 // 		await subject.restore();
@@ -422,7 +422,7 @@ test("#update", async () => {
 // 	});
 
 // 	// @TODO: implement mockImplementationOnce
-// 	suite.skip("should retry if it encounters a failure during restoration", async () => {
+// 	skip("should retry if it encounters a failure during restoration", async () => {
 // 		// Nasty: we need to mock a failure on the wallet instance the repository has
 // 		mockery(subject.findById(wallet.id()), "mutator").mockImplementationOnce(() => {
 // 			throw new Error();

--- a/packages/profiles/source/wallet.service.test.js
+++ b/packages/profiles/source/wallet.service.test.js
@@ -99,19 +99,17 @@ test.after.each(() => {
 
 test.before(() => nock.disableNetConnect());
 
-describe("WalletService", () => {
-	test("#syncByProfile", async () => {
-		assert.throws(() => wallet.voting().current(), /has not been synced/);
+test("#syncByProfile", async () => {
+	assert.throws(() => wallet.voting().current(), /has not been synced/);
 
-		await subject.syncByProfile(profile);
+	await subject.syncByProfile(profile);
 
-		assert.not.throws(() => wallet.voting().current(), /has not been synced/);
+	assert.not.throws(() => wallet.voting().current(), /has not been synced/);
 
-		// @ts-ignore
-		const mockUndefinedWallets = mockery(profile.wallets(), "values").mockReturnValue([undefined]);
-		await subject.syncByProfile(profile);
-		mockUndefinedWallets.mockRestore();
-	});
+	// @ts-ignore
+	const mockUndefinedWallets = mockery(profile.wallets(), "values").mockReturnValue([undefined]);
+	await subject.syncByProfile(profile);
+	mockUndefinedWallets.mockRestore();
 });
 
 test.run();

--- a/packages/profiles/test/mocking.ts
+++ b/packages/profiles/test/mocking.ts
@@ -19,7 +19,7 @@ export const bootContainer = (): void => {
 		coins: { ADA, ARK, BTC, ETH, LSK },
 		storage: new StubStorage(),
 		httpClient: new Request(),
-		ledgerTransportFactory: async () => {},
+		ledgerTransportFactory: async () => { },
 	});
 };
 

--- a/packages/profiles/test/mocking.ts
+++ b/packages/profiles/test/mocking.ts
@@ -19,7 +19,7 @@ export const bootContainer = (): void => {
 		coins: { ADA, ARK, BTC, ETH, LSK },
 		storage: new StubStorage(),
 		httpClient: new Request(),
-		ledgerTransportFactory: async () => { },
+		ledgerTransportFactory: async () => {},
 	});
 };
 

--- a/packages/profiles/test/musig/ark.musig.registration.test.js
+++ b/packages/profiles/test/musig/ark.musig.registration.test.js
@@ -13,7 +13,7 @@ import {
 	generateRegistrationTransactionData,
 } from "./musig.test.helpers";
 
-describe("ARK", () => {
+describe("ARK", ({ afterEach, beforeEach, test }) => {
 	let profile;
 	const { mockServerResponse, resetServerResponseMocks } = mockMusigServer({
 		url: "https://ark-test-musig.payvo.com",
@@ -50,7 +50,7 @@ describe("ARK", () => {
 		resetServerResponseMocks();
 	});
 
-	describe("MuSig Registration", () => {
+	describe("MuSig Registration", ({ afterEach, beforeEach, test }) => {
 		test("should perform a 2 out of 2 registration", async () => {
 			const { wallets, publicKeys } = await generateWallets({
 				numberOfWallets: 2,

--- a/packages/profiles/test/musig/lsk.musig.registration.test.js
+++ b/packages/profiles/test/musig/lsk.musig.registration.test.js
@@ -13,7 +13,7 @@ import {
 	generateRegistrationTransactionData,
 } from "./musig.test.helpers";
 
-describe("LSK", () => {
+describe("LSK", ({ afterEach, beforeEach, test }) => {
 	let profile;
 
 	const { mockServerResponse, resetServerResponseMocks } = mockMusigServer({
@@ -39,7 +39,7 @@ describe("LSK", () => {
 		resetServerResponseMocks();
 	});
 
-	describe("MuSig Registration", () => {
+	describe("MuSig Registration", ({ afterEach, beforeEach, test }) => {
 		// it.each(["mandatory", "optional"])(
 		// 	"should perform a 2 out of 2 registration using all keys as %s",
 		// 	async (key) => {

--- a/packages/sdk/source/signatory.test.js
+++ b/packages/sdk/source/signatory.test.js
@@ -10,7 +10,7 @@ import { SecretSignatory } from "./secret.signatory";
 import { Signatory } from "./signatory";
 import { WIFSignatory } from "./wif.signatory";
 
-describe("MnemonicSignatory", (test) => {
+describe("MnemonicSignatory", ({ afterEach, beforeEach, test }) => {
 	test("#signingKey", () => {
 		const subject = new Signatory(
 			new MnemonicSignatory({
@@ -134,7 +134,7 @@ describe("MnemonicSignatory", (test) => {
 	});
 });
 
-describe("ConfirmationMnemonicSignatory", (test) => {
+describe("ConfirmationMnemonicSignatory", ({ afterEach, beforeEach, test }) => {
 	test("#signingKey", () => {
 		const subject = new Signatory(
 			new ConfirmationMnemonicSignatory({
@@ -231,7 +231,7 @@ describe("ConfirmationMnemonicSignatory", (test) => {
 	});
 });
 
-describe("WIFSignatory", (test) => {
+describe("WIFSignatory", ({ afterEach, beforeEach, test }) => {
 	test("#signingKey", () => {
 		const subject = new Signatory(
 			new WIFSignatory({
@@ -322,7 +322,7 @@ describe("WIFSignatory", (test) => {
 	});
 });
 
-describe("ConfirmationWIFSignatory", (test) => {
+describe("ConfirmationWIFSignatory", ({ afterEach, beforeEach, test }) => {
 	test("#signingKey", () => {
 		const subject = new Signatory(
 			new ConfirmationWIFSignatory({
@@ -419,7 +419,7 @@ describe("ConfirmationWIFSignatory", (test) => {
 	});
 });
 
-describe("PrivateKeySignatory", (test) => {
+describe("PrivateKeySignatory", ({ afterEach, beforeEach, test }) => {
 	test("#signingKey", () => {
 		const subject = new Signatory(
 			new PrivateKeySignatory({
@@ -529,7 +529,7 @@ describe("PrivateKeySignatory", (test) => {
 	});
 });
 
-describe("MultiSignatureSignatory", (test) => {
+describe("MultiSignatureSignatory", ({ afterEach, beforeEach, test }) => {
 	test("#signingKey", () => {
 		const subject = new Signatory(
 			new MultiSignatureSignatory({ min: 5, publicKeys: ["identifier"] }, "identifier"),
@@ -579,7 +579,7 @@ describe("MultiSignatureSignatory", (test) => {
 	});
 });
 
-describe("ConfirmationSecretSignatory", (test) => {
+describe("ConfirmationSecretSignatory", ({ afterEach, beforeEach, test }) => {
 	test("#signingKey", () => {
 		const subject = new Signatory(
 			new ConfirmationSecretSignatory({

--- a/packages/test/source/describe.test.js
+++ b/packages/test/source/describe.test.js
@@ -1,15 +1,15 @@
 import { describe } from "./describe";
 
-describe("Date.now()", ({ assert, before, after, only, skip, test }) => {
+describe("Date.now()", ({ assert, beforeAll, afterAll, only, skip, test }) => {
 	let _Date;
 
-	before(() => {
+	beforeAll(() => {
 		let count = 0;
 		_Date = global.Date;
 		global.Date = { now: () => 100 + count++ };
 	});
 
-	after(() => {
+	afterAll(() => {
 		global.Date = _Date;
 	});
 

--- a/packages/test/source/describe.ts
+++ b/packages/test/source/describe.ts
@@ -6,10 +6,10 @@ export const describe = (title: string, callback: Function): void => {
 	const instance = suite(title);
 
 	callback({
-		after: instance.after,
+		afterAll: instance.after,
 		afterEach: instance.after.each,
 		assert,
-		before: instance.before,
+		beforeAll: instance.before,
 		beforeEach: instance.before.each,
 		it: instance,
 		only: instance.only,

--- a/packages/xlm/source/keys.service.test.js
+++ b/packages/xlm/source/keys.service.test.js
@@ -9,24 +9,22 @@ test.before.each(async () => {
 	subject = await createService(KeyPairService);
 });
 
-describe("Keys", () => {
-	test("should generate an output from a mnemonic", async () => {
-		const result = await subject.fromMnemonic(identity.mnemonic);
+test("should generate an output from a mnemonic", async () => {
+	const result = await subject.fromMnemonic(identity.mnemonic);
 
-		assert.equal(result, {
-			path: "m/44'/148'/0'",
-			privateKey: "SCVPKP4VG6NDJHHGQ7OLDGWO6TZMZTUCKRMKUQ3KDGHCAJ7J5RG3L7WC",
-			publicKey: "GCGYSPQBSQCJKNDXDISBSXAM3THK7MACUVZGEMXF6XRZCPGAWCUGXVNC",
-		});
+	assert.equal(result, {
+		path: "m/44'/148'/0'",
+		privateKey: "SCVPKP4VG6NDJHHGQ7OLDGWO6TZMZTUCKRMKUQ3KDGHCAJ7J5RG3L7WC",
+		publicKey: "GCGYSPQBSQCJKNDXDISBSXAM3THK7MACUVZGEMXF6XRZCPGAWCUGXVNC",
 	});
+});
 
-	test("should generate an output from a private key", async () => {
-		const result = await subject.fromPrivateKey(identity.privateKey);
+test("should generate an output from a private key", async () => {
+	const result = await subject.fromPrivateKey(identity.privateKey);
 
-		assert.equal(result, {
-			privateKey: identity.privateKey,
-			publicKey: identity.publicKey,
-		});
+	assert.equal(result, {
+		privateKey: identity.privateKey,
+		publicKey: identity.publicKey,
 	});
 });
 

--- a/packages/xlm/source/ledger.service.test.js
+++ b/packages/xlm/source/ledger.service.test.js
@@ -33,7 +33,7 @@ const createMockService = async (record) => {
 	return transport;
 };
 
-describe("disconnect", () => {
+describe("disconnect", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a resolved transport closure", async () => {
 		const trx = await createMockService("");
 
@@ -41,7 +41,7 @@ describe("disconnect", () => {
 	});
 });
 
-describe("getVersion", () => {
+describe("getVersion", ({ afterEach, beforeEach, test }) => {
 	test("should pass with an app version", async () => {
 		const trx = await createMockService(ledger.appVersion.record);
 
@@ -49,7 +49,7 @@ describe("getVersion", () => {
 	});
 });
 
-describe("getPublicKey", () => {
+describe("getPublicKey", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a compressed publicKey", async () => {
 		const trx = await createMockService(ledger.publicKey.record);
 
@@ -57,7 +57,7 @@ describe("getPublicKey", () => {
 	});
 });
 
-describe("signTransaction", () => {
+describe("signTransaction", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a signature", async () => {
 		const trx = await createMockService(ledger.transaction.record);
 
@@ -68,7 +68,7 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signMessage", () => {
+describe("signMessage", ({ afterEach, beforeEach, test }) => {
 	test("should fail with a 'NotImplemented' error", async () => {
 		const trx = await createMockService("");
 

--- a/packages/xrp/source/client.service.test.js
+++ b/packages/xrp/source/client.service.test.js
@@ -1,5 +1,4 @@
-import { assert, describe, loader, test } from "@payvo/sdk-test";
-
+import { assert, loader, test } from "@payvo/sdk-test";
 import { IoC, Services } from "@payvo/sdk";
 import { DateTime } from "@payvo/sdk-intl";
 import { BigNumber } from "@payvo/sdk-helpers";
@@ -63,53 +62,49 @@ test("#transactions", async () => {
 	assert.equal(result.items()[0].fee(), BigNumber.make(1000));
 });
 
-describe("#wallet", () => {
-	test("should succeed", async () => {
-		nock(/.+/).post("/").reply(200, loader.json(`test/fixtures/client/wallet.json`));
+test("#wallet", async () => {
+	nock(/.+/).post("/").reply(200, loader.json(`test/fixtures/client/wallet.json`));
 
-		const result = await subject.wallet({
-			type: "address",
-			value: "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-		});
-
-		assert.instance(result, WalletData);
-		assert.is(result.address(), "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59");
-		assert.undefined(result.publicKey());
-		assert.equal(result.balance().available, BigNumber.make("92291324300"));
+	const result = await subject.wallet({
+		type: "address",
+		value: "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
 	});
 
-	describe("#broadcast", () => {
-		const transactionPayload = createService(SignedTransactionData).configure(
-			"id",
-			"12000322000000002400000017201B0086955468400000000000000C732102F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D87446304402207660BDEF67105CE1EBA9AD35DC7156BAB43FF1D47633199EE257D70B6B9AAFBF02207F5517BC8AEF2ADC1325897ECDBA8C673838048BCA62F4E98B252F19BE88796D770A726970706C652E636F6D81144FBFF73DA4ECF9B701940F27341FA8020C313443",
-			"12000322000000002400000017201B0086955468400000000000000C732102F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D87446304402207660BDEF67105CE1EBA9AD35DC7156BAB43FF1D47633199EE257D70B6B9AAFBF02207F5517BC8AEF2ADC1325897ECDBA8C673838048BCA62F4E98B252F19BE88796D770A726970706C652E636F6D81144FBFF73DA4ECF9B701940F27341FA8020C313443",
-		);
+	assert.instance(result, WalletData);
+	assert.is(result.address(), "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59");
+	assert.undefined(result.publicKey());
+	assert.equal(result.balance().available, BigNumber.make("92291324300"));
+});
 
-		test("broadcast should pass", async () => {
-			nock(/.+/).post("/").reply(200, loader.json(`test/fixtures/client/broadcast.json`));
+const transactionPayload = createService(SignedTransactionData).configure(
+	"id",
+	"12000322000000002400000017201B0086955468400000000000000C732102F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D87446304402207660BDEF67105CE1EBA9AD35DC7156BAB43FF1D47633199EE257D70B6B9AAFBF02207F5517BC8AEF2ADC1325897ECDBA8C673838048BCA62F4E98B252F19BE88796D770A726970706C652E636F6D81144FBFF73DA4ECF9B701940F27341FA8020C313443",
+	"12000322000000002400000017201B0086955468400000000000000C732102F89EAEC7667B30F33D0687BBA86C3FE2A08CCA40A9186C5BDE2DAA6FA97A37D87446304402207660BDEF67105CE1EBA9AD35DC7156BAB43FF1D47633199EE257D70B6B9AAFBF02207F5517BC8AEF2ADC1325897ECDBA8C673838048BCA62F4E98B252F19BE88796D770A726970706C652E636F6D81144FBFF73DA4ECF9B701940F27341FA8020C313443",
+);
 
-			const result = await subject.broadcast([transactionPayload]);
+test("broadcast should pass", async () => {
+	nock(/.+/).post("/").reply(200, loader.json(`test/fixtures/client/broadcast.json`));
 
-			assert.equal(result, {
-				accepted: ["2B6928A583A9D14D359E471EB8D8F961CBC1A054EF86845A39790A7912147CD2"],
-				rejected: [],
-				errors: {},
-			});
-		});
+	const result = await subject.broadcast([transactionPayload]);
 
-		test("broadcast should fail", async () => {
-			nock(/.+/).post("/").reply(200, loader.json(`test/fixtures/client/broadcast-failure.json`));
+	assert.equal(result, {
+		accepted: ["2B6928A583A9D14D359E471EB8D8F961CBC1A054EF86845A39790A7912147CD2"],
+		rejected: [],
+		errors: {},
+	});
+});
 
-			const result = await subject.broadcast([transactionPayload]);
+test("broadcast should fail", async () => {
+	nock(/.+/).post("/").reply(200, loader.json(`test/fixtures/client/broadcast-failure.json`));
 
-			assert.equal(result, {
-				accepted: [],
-				rejected: [transactionPayload.id()],
-				errors: {
-					[transactionPayload.id()]: "tecUNFUNDED_PAYMENT",
-				},
-			});
-		});
+	const result = await subject.broadcast([transactionPayload]);
+
+	assert.equal(result, {
+		accepted: [],
+		rejected: [transactionPayload.id()],
+		errors: {
+			[transactionPayload.id()]: "tecUNFUNDED_PAYMENT",
+		},
 	});
 });
 

--- a/packages/xrp/source/ledger.service.test.js
+++ b/packages/xrp/source/ledger.service.test.js
@@ -33,7 +33,7 @@ const createMockService = async (record) => {
 	return transport;
 };
 
-describe("disconnect", () => {
+describe("disconnect", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a resolved transport closure", async () => {
 		const xrp = await createMockService("");
 
@@ -41,7 +41,7 @@ describe("disconnect", () => {
 	});
 });
 
-describe("getVersion", () => {
+describe("getVersion", ({ afterEach, beforeEach, test }) => {
 	test("should pass with an app version", async () => {
 		const xrp = await createMockService(ledger.appVersion.record);
 
@@ -49,7 +49,7 @@ describe("getVersion", () => {
 	});
 });
 
-describe("getPublicKey", () => {
+describe("getPublicKey", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a compressed publicKey", async () => {
 		const xrp = await createMockService(ledger.publicKey.record);
 
@@ -57,7 +57,7 @@ describe("getPublicKey", () => {
 	});
 });
 
-describe("signTransaction", () => {
+describe("signTransaction", ({ afterEach, beforeEach, test }) => {
 	test("should pass with a signature", async () => {
 		const xrp = await createMockService(ledger.transaction.record);
 
@@ -68,7 +68,7 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signMessage", () => {
+describe("signMessage", ({ afterEach, beforeEach, test }) => {
 	test("should fail with a 'NotImplemented' error", async () => {
 		const xrp = await createMockService("");
 


### PR DESCRIPTION
> Follow-up to https://github.com/PayvoHQ/sdk/pull/429

Updates `describe` blocks to use the new destructing to access all hooks. This does not rework the `describe` blocks that are commented out.