### PR TITLE
feat(test): implement context for describe

### DIFF
--- a/packages/test/source/describe.test.js
+++ b/packages/test/source/describe.test.js
@@ -39,3 +39,9 @@ describeWithContext("Context (Function)", () => ({ hello: "world" }), ({ assert,
 		assert.is(context.hello, "world");
 	});
 });
+
+describeWithContext("Context (Promise Function)", async () => Promise.resolve({ hello: "world" }), ({ assert,  test }) => {
+	test("should have context from an object", (context) => {
+		assert.is(context.hello, "world");
+	});
+});

--- a/packages/test/source/describe.test.js
+++ b/packages/test/source/describe.test.js
@@ -28,20 +28,28 @@ describe("Date.now()", ({ assert, beforeAll, afterAll, only, skip, test }) => {
 	});
 });
 
-describeWithContext("Context (Object)", { hello: "world" }, ({ assert,  test }) => {
+describeWithContext("Context (Object)", { hello: "world" }, ({ assert, test }) => {
 	test("should have context from an object", (context) => {
 		assert.is(context.hello, "world");
 	});
 });
 
-describeWithContext("Context (Function)", () => ({ hello: "world" }), ({ assert,  test }) => {
-	test("should have context from an object", (context) => {
-		assert.is(context.hello, "world");
-	});
-});
+describeWithContext(
+	"Context (Function)",
+	() => ({ hello: "world" }),
+	({ assert, test }) => {
+		test("should have context from an object", (context) => {
+			assert.is(context.hello, "world");
+		});
+	},
+);
 
-describeWithContext("Context (Promise Function)", async () => Promise.resolve({ hello: "world" }), ({ assert,  test }) => {
-	test("should have context from an object", (context) => {
-		assert.is(context.hello, "world");
-	});
-});
+describeWithContext(
+	"Context (Promise Function)",
+	async () => Promise.resolve({ hello: "world" }),
+	({ assert, test }) => {
+		test("should have context from an object", (context) => {
+			assert.is(context.hello, "world");
+		});
+	},
+);

--- a/packages/test/source/describe.test.js
+++ b/packages/test/source/describe.test.js
@@ -1,4 +1,4 @@
-import { describe } from "./describe";
+import { describe, describeWithContext } from "./describe";
 
 describe("Date.now()", ({ assert, beforeAll, afterAll, only, skip, test }) => {
 	let _Date;
@@ -25,5 +25,17 @@ describe("Date.now()", ({ assert, beforeAll, afterAll, only, skip, test }) => {
 		assert.is(Date.now(), 100);
 		assert.is(Date.now(), 101);
 		assert.is(Date.now(), 102);
+	});
+});
+
+describeWithContext("Context (Object)", { hello: "world" }, ({ assert,  test }) => {
+	test("should have context from an object", (context) => {
+		assert.is(context.hello, "world");
+	});
+});
+
+describeWithContext("Context (Function)", () => ({ hello: "world" }), ({ assert,  test }) => {
+	test("should have context from an object", (context) => {
+		assert.is(context.hello, "world");
 	});
 });

--- a/packages/test/source/describe.ts
+++ b/packages/test/source/describe.ts
@@ -3,6 +3,7 @@ import { Context, suite, Test } from "uvu";
 import { assert } from "./assert.js";
 
 type ContextFunction = () => Context;
+type ContextPromise = () => Promise<Context>;
 
 const runSuite = (suite: Test, callback: Function): void => {
 	callback({
@@ -22,5 +23,5 @@ const runSuite = (suite: Test, callback: Function): void => {
 
 export const describe = (title: string, callback: Function): void => runSuite(suite(title), callback);
 
-export const describeWithContext = (title: string, context: Context | ContextFunction, callback: Function): void =>
-	runSuite(suite(title, typeof context === "function" ? context() : context), callback)
+export const describeWithContext = async (title: string, context: Context | ContextFunction | ContextPromise, callback: Function): Promise<void> =>
+	runSuite(suite(title, typeof context === "function" ? await context() : context), callback)

--- a/packages/test/source/describe.ts
+++ b/packages/test/source/describe.ts
@@ -19,9 +19,12 @@ const runSuite = (suite: Test, callback: Function): void => {
 	});
 
 	suite.run();
-}
+};
 
 export const describe = (title: string, callback: Function): void => runSuite(suite(title), callback);
 
-export const describeWithContext = async (title: string, context: Context | ContextFunction | ContextPromise, callback: Function): Promise<void> =>
-	runSuite(suite(title, typeof context === "function" ? await context() : context), callback)
+export const describeWithContext = async (
+	title: string,
+	context: Context | ContextFunction | ContextPromise,
+	callback: Function,
+): Promise<void> => runSuite(suite(title, typeof context === "function" ? await context() : context), callback);

--- a/packages/test/source/describe.ts
+++ b/packages/test/source/describe.ts
@@ -1,21 +1,26 @@
-import { suite } from "uvu";
+import { Context, suite, Test } from "uvu";
 
 import { assert } from "./assert.js";
 
-export const describe = (title: string, callback: Function): void => {
-	const instance = suite(title);
+type ContextFunction = () => Context;
 
+const runSuite = (suite: Test, callback: Function): void => {
 	callback({
-		afterAll: instance.after,
-		afterEach: instance.after.each,
+		afterAll: suite.after,
+		afterEach: suite.after.each,
 		assert,
-		beforeAll: instance.before,
-		beforeEach: instance.before.each,
-		it: instance,
-		only: instance.only,
-		skip: instance.skip,
-		test: instance,
+		beforeAll: suite.before,
+		beforeEach: suite.before.each,
+		it: suite,
+		only: suite.only,
+		skip: suite.skip,
+		test: suite,
 	});
 
-	instance.run();
-};
+	suite.run();
+}
+
+export const describe = (title: string, callback: Function): void => runSuite(suite(title), callback);
+
+export const describeWithContext = (title: string, context: Context | ContextFunction, callback: Function): void =>
+	runSuite(suite(title, typeof context === "function" ? context() : context), callback)


### PR DESCRIPTION
Implements a new `describeWithContext` method that can be used to create a pre-defined context for all tests within a suite. The context can be either an object, function or async function. If an async function is used the `describe` has to be awaited for the context function to resolve.

**Note:** Using this context is similar to using `beforeAll` and setting context. This is more of a handy shorthand, especially if you have some default objects for some constant values.