### PR TITLE
feat(test): implement datasets

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -899,6 +899,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "string-kit",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "terminal-link",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1901,6 +1901,7 @@ importers:
       concordance: 5.0.4
       nock: 13.2.0
       sinon: 12.0.1
+      string-kit: 0.14.2
       tsm: 2.1.4
       uvu: 0.5.2
       watchlist: 0.3.1
@@ -1914,6 +1915,7 @@ importers:
       concordance: ~5.0.4
       nock: ^13.2.0
       sinon: ^12.0.1
+      string-kit: ~0.14.2
       tsm: ^2.1.4
       uvu: ^0.5.2
       watchlist: ~0.3.1
@@ -11352,6 +11354,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-LhWeKBSpThCr/XEIltPNNfg9Rp10Ei/xPYANF2Y4ezaoXuF0fOU2vjwRfcaK1kgavkKkBqMWvh222cscP9myCA==
+  /string-kit/0.14.2:
+    dev: false
+    engines:
+      node: '>=14.15.0'
+    resolution:
+      integrity: sha512-u8vgcSh/IctgL7vnl+p/BfO535PA3HXaOHgnfHdiOm0ZleQkTBkEIfZjK7/uiyDkLjU/hERNwuAKXZdUTCWzZQ==
   /string-width/1.0.2:
     dependencies:
       code-point-at: 1.1.0

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "6044bce133bb6ff2a4c8cd09651ae346e23258ac",
+  "pnpmShrinkwrapHash": "2b92b0f0ea5fc1a347d92f4e502d03bbfe9fc870",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -30,7 +30,8 @@
 		"watchlist": "~0.3.1",
 		"zod": "~3.11.6",
 		"concordance": "~5.0.4",
-		"yargs": "~17.2.1"
+		"yargs": "~17.2.1",
+		"string-kit": "~0.14.2"
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7"

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -23,15 +23,15 @@
 	},
 	"dependencies": {
 		"c8": "~7.10.0",
+		"concordance": "~5.0.4",
 		"nock": "^13.2.0",
 		"sinon": "^12.0.1",
+		"string-kit": "~0.14.2",
 		"tsm": "^2.1.4",
 		"uvu": "^0.5.2",
 		"watchlist": "~0.3.1",
-		"zod": "~3.11.6",
-		"concordance": "~5.0.4",
 		"yargs": "~17.2.1",
-		"string-kit": "~0.14.2"
+		"zod": "~3.11.6"
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.7"

--- a/packages/test/source/describe.test.js
+++ b/packages/test/source/describe.test.js
@@ -1,6 +1,6 @@
 import { describe, describeWithContext } from "./describe";
 
-describe("Date.now()", ({ assert, beforeAll, afterAll, only, skip, test }) => {
+describe("Date.now()", ({ assert, beforeAll, afterAll, each, only, skip, test }) => {
 	let _Date;
 
 	beforeAll(() => {
@@ -26,6 +26,11 @@ describe("Date.now()", ({ assert, beforeAll, afterAll, only, skip, test }) => {
 		assert.is(Date.now(), 101);
 		assert.is(Date.now(), 102);
 	});
+
+	each("should progress with time", ({ dataset }) => {
+		console.log(dataset)
+		assert.true(dataset > 0);
+	}, [1, 2, 3]);
 });
 
 describeWithContext("Context (Object)", { hello: "world" }, ({ assert, test }) => {

--- a/packages/test/source/describe.test.js
+++ b/packages/test/source/describe.test.js
@@ -29,9 +29,13 @@ describe("Date.now()", ({ assert, beforeAll, afterAll, each, only, skip, test })
 });
 
 describe("Datasets", ({ assert, each }) => {
-	each("number %s should be greater than 0", ({ dataset }) => {
-		assert.true(dataset > 0);
-	}, Array.from({ length: 32 },(_, index) =>index + 1));
+	each(
+		"number %s should be greater than 0",
+		({ dataset }) => {
+			assert.true(dataset > 0);
+		},
+		Array.from({ length: 32 }, (_, index) => index + 1),
+	);
 });
 
 describeWithContext("Context (Object)", { hello: "world" }, ({ assert, test }) => {

--- a/packages/test/source/describe.test.js
+++ b/packages/test/source/describe.test.js
@@ -27,7 +27,7 @@ describe("Date.now()", ({ assert, beforeAll, afterAll, each, only, skip, test })
 		assert.is(Date.now(), 102);
 	});
 
-	each("should progress with time", ({ dataset }) => {
+	each("number ", ({ dataset }) => {
 		console.log(dataset)
 		assert.true(dataset > 0);
 	}, [1, 2, 3]);

--- a/packages/test/source/describe.test.js
+++ b/packages/test/source/describe.test.js
@@ -26,11 +26,12 @@ describe("Date.now()", ({ assert, beforeAll, afterAll, each, only, skip, test })
 		assert.is(Date.now(), 101);
 		assert.is(Date.now(), 102);
 	});
+});
 
-	each("number ", ({ dataset }) => {
-		console.log(dataset)
+describe("Datasets", ({ assert, each }) => {
+	each("number %s should be greater than 0", ({ dataset }) => {
 		assert.true(dataset > 0);
-	}, [1, 2, 3]);
+	}, Array.from({ length: 32 },(_, index) =>index + 1));
 });
 
 describeWithContext("Context (Object)", { hello: "world" }, ({ assert, test }) => {

--- a/packages/test/source/describe.ts
+++ b/packages/test/source/describe.ts
@@ -1,6 +1,7 @@
 import { Context, suite, Test } from "uvu";
 
 import { assert } from "./assert.js";
+import { eachSuite } from "./each.js";
 import { Mockery } from "./mockery.js";
 
 type ContextFunction = () => Context;
@@ -13,6 +14,7 @@ const runSuite = (suite: Test, callback: Function): void => {
 		assert,
 		beforeAll: suite.before,
 		beforeEach: suite.before.each,
+		each: eachSuite(suite),
 		it: suite,
 		mock: Mockery.mock,
 		only: suite.only,

--- a/packages/test/source/each.ts
+++ b/packages/test/source/each.ts
@@ -1,16 +1,19 @@
+import { format } from "string-kit";
 import { Callback, Context, Test, test } from "uvu";
+
+const formatName = (name: string, ...dataset): string => format(name, dataset);
 
 export const each = (name: string, callback: Callback<any>, datasets: unknown[]) => {
 	for (const dataset of datasets) {
-		test(name, async (context: Context) => callback({ context, dataset }));
+		test(formatName(name), async (context: Context) => callback({ context, dataset }));
 	}
 }
-
 
 export const eachSuite = (test: Test) => {
 	return (name: string, callback: Callback<any>, datasets: unknown[]) => {
 		for (const dataset of datasets) {
-			test(name, async (context: Context) => callback({ context, dataset }));
+			console.log()
+			test(formatName(name), async (context: Context) => callback({ context, dataset }));
 		}
 	}
 }

--- a/packages/test/source/each.ts
+++ b/packages/test/source/each.ts
@@ -1,0 +1,16 @@
+import { Callback, Context, Test, test } from "uvu";
+
+export const each = (name: string, callback: Callback<any>, datasets: unknown[]) => {
+	for (const dataset of datasets) {
+		test(name, async (context: Context) => callback({ context, dataset }));
+	}
+}
+
+
+export const eachSuite = (test: Test) => {
+	return (name: string, callback: Callback<any>, datasets: unknown[]) => {
+		for (const dataset of datasets) {
+			test(name, async (context: Context) => callback({ context, dataset }));
+		}
+	}
+}

--- a/packages/test/source/each.ts
+++ b/packages/test/source/each.ts
@@ -1,7 +1,7 @@
 import { format } from "string-kit";
 import { Callback, Context, Test, test } from "uvu";
 
-const formatName = (name: string, ...dataset): string => format(name, dataset);
+const formatName = (name: string, ...dataset: unknown[]): string => format(name, dataset);
 
 export const each = (name: string, callback: Callback<any>, datasets: unknown[]) => {
 	for (const dataset of datasets) {
@@ -12,7 +12,6 @@ export const each = (name: string, callback: Callback<any>, datasets: unknown[])
 export const eachSuite = (test: Test) => {
 	return (name: string, callback: Callback<any>, datasets: unknown[]) => {
 		for (const dataset of datasets) {
-			console.log()
 			test(formatName(name), async (context: Context) => callback({ context, dataset }));
 		}
 	}

--- a/packages/test/source/each.ts
+++ b/packages/test/source/each.ts
@@ -5,14 +5,14 @@ const formatName = (name: string, ...dataset: unknown[]): string => format(name,
 
 export const each = (name: string, callback: Callback<any>, datasets: unknown[]) => {
 	for (const dataset of datasets) {
-		test(formatName(name), async (context: Context) => callback({ context, dataset }));
+		test(formatName(name, dataset), async (context: Context) => callback({ context, dataset }));
 	}
 };
 
 export const eachSuite = (test: Test) => {
 	return (name: string, callback: Callback<any>, datasets: unknown[]) => {
 		for (const dataset of datasets) {
-			test(formatName(name), async (context: Context) => callback({ context, dataset }));
+			test(formatName(name, dataset), async (context: Context) => callback({ context, dataset }));
 		}
 	};
 };

--- a/packages/test/source/each.ts
+++ b/packages/test/source/each.ts
@@ -14,5 +14,5 @@ export const eachSuite = (test: Test) => {
 		for (const dataset of datasets) {
 			test(formatName(name), async (context: Context) => callback({ context, dataset }));
 		}
-	}
+	};
 };


### PR DESCRIPTION
> Resolves https://github.com/PayvoHQ/sdk/issues/436

Implements an API to use datasets that has a nicer syntax than what jest has. You simply pass an array of datasets as the last argument that's it. They can then be accessed through the `dataset` property in the test callback.