### PR TITLE
refactor(test): always clean nock mocks in `after` hooks

### DIFF
--- a/packages/ark/source/client.service.test.js
+++ b/packages/ark/source/client.service.test.js
@@ -23,7 +23,7 @@ describe("AddressService", async ({ assert, afterEach, beforeAll, it, loader }) 
 		});
 	});
 
-	afterEach(() => nock.cleanAll());
+
 
 	it("should retrieve a transaction", async () => {
 		nock.fake(/.+/)

--- a/packages/ark/source/client.service.test.js
+++ b/packages/ark/source/client.service.test.js
@@ -23,8 +23,6 @@ describe("AddressService", async ({ assert, afterEach, beforeAll, it, loader }) 
 		});
 	});
 
-
-
 	it("should retrieve a transaction", async () => {
 		nock.fake(/.+/)
 			.get("/api/transactions/3e3817fd0c35bc36674f3874c2953fa3e35877cbcdb44a08bdc6083dbd39d572")

--- a/packages/ark/source/fee.service.test.js
+++ b/packages/ark/source/fee.service.test.js
@@ -27,8 +27,6 @@ const normaliseFees = (transaction) => ({
 });
 
 describe("FeeService", async ({ assert, afterEach, it, loader }) => {
-
-
 	it("should get the fees for ARK", async () => {
 		nock.fake(/.+/)
 			.get("/api/node/fees")

--- a/packages/ark/source/fee.service.test.js
+++ b/packages/ark/source/fee.service.test.js
@@ -27,7 +27,7 @@ const normaliseFees = (transaction) => ({
 });
 
 describe("FeeService", async ({ assert, afterEach, it, loader }) => {
-	afterEach(() => nock.cleanAll());
+
 
 	it("should get the fees for ARK", async () => {
 		nock.fake(/.+/)

--- a/packages/ark/source/known-wallet.service.test.js
+++ b/packages/ark/source/known-wallet.service.test.js
@@ -14,8 +14,6 @@ describe("KnownWalletService", async ({ assert, afterEach, beforeAll, beforeEach
 		subject = await createService(KnownWalletService);
 	});
 
-
-
 	it("should return a list of known wallets if the request succeeds", async () => {
 		const wallets = [
 			{

--- a/packages/ark/source/known-wallet.service.test.js
+++ b/packages/ark/source/known-wallet.service.test.js
@@ -14,7 +14,7 @@ describe("KnownWalletService", async ({ assert, afterEach, beforeAll, beforeEach
 		subject = await createService(KnownWalletService);
 	});
 
-	afterEach(() => nock.cleanAll());
+
 
 	it("should return a list of known wallets if the request succeeds", async () => {
 		const wallets = [

--- a/packages/ark/source/ledger.service.test.js
+++ b/packages/ark/source/ledger.service.test.js
@@ -95,7 +95,7 @@ describe("LedgerService", async ({ assert, it }) => {
 describe("LedgerService - scan", ({ assert, afterEach, beforeAll, it, loader, stub }) => {
 	beforeAll(() => nock.disableNetConnect());
 
-	afterEach(() => nock.cleanAll());
+
 
 	it("should scan for legacy wallets", async () => {
 		nock.fake(/.+/)

--- a/packages/ark/source/ledger.service.test.js
+++ b/packages/ark/source/ledger.service.test.js
@@ -95,8 +95,6 @@ describe("LedgerService", async ({ assert, it }) => {
 describe("LedgerService - scan", ({ assert, afterEach, beforeAll, it, loader, stub }) => {
 	beforeAll(() => nock.disableNetConnect());
 
-
-
 	it("should scan for legacy wallets", async () => {
 		nock.fake(/.+/)
 			.get(

--- a/packages/ark/source/multi-signature.service.test.js
+++ b/packages/ark/source/multi-signature.service.test.js
@@ -41,7 +41,7 @@ describe("MultiSignatureService", async ({ assert, afterEach, beforeAll, beforeE
 		fixtures = loader.json(`test/fixtures/client/multisig-transactions.json`);
 	});
 
-	afterEach(() => nock.cleanAll());
+
 
 	let fixtures;
 

--- a/packages/ark/source/multi-signature.service.test.js
+++ b/packages/ark/source/multi-signature.service.test.js
@@ -41,8 +41,6 @@ describe("MultiSignatureService", async ({ assert, afterEach, beforeAll, beforeE
 		fixtures = loader.json(`test/fixtures/client/multisig-transactions.json`);
 	});
 
-
-
 	let fixtures;
 
 	it("should list all all transaction With a PendingState", async () => {

--- a/packages/ark/source/transaction.service.test.js
+++ b/packages/ark/source/transaction.service.test.js
@@ -41,7 +41,7 @@ describe("TransactionService", async ({ assert, afterEach, beforeAll, it, loader
 		});
 	});
 
-	afterEach(() => nock.cleanAll());
+
 
 	it("should create a transfer", async () => {
 		const result = await subject.transfer({

--- a/packages/ark/source/transaction.service.test.js
+++ b/packages/ark/source/transaction.service.test.js
@@ -41,8 +41,6 @@ describe("TransactionService", async ({ assert, afterEach, beforeAll, it, loader
 		});
 	});
 
-
-
 	it("should create a transfer", async () => {
 		const result = await subject.transfer({
 			nonce: "1",

--- a/packages/lsk/source/ledger.service.test.js
+++ b/packages/lsk/source/ledger.service.test.js
@@ -109,8 +109,6 @@ describe("signMessage", ({ afterEach, beforeEach, test }) => {
 });
 
 describe("scan", ({ afterEach, beforeAll, test }) => {
-
-
 	beforeAll(() => nock.disableNetConnect());
 
 	test("should return scanned wallet", async () => {

--- a/packages/lsk/source/ledger.service.test.js
+++ b/packages/lsk/source/ledger.service.test.js
@@ -109,7 +109,7 @@ describe("signMessage", ({ afterEach, beforeEach, test }) => {
 });
 
 describe("scan", ({ afterEach, beforeAll, test }) => {
-	afterEach(() => nock.cleanAll());
+
 
 	beforeAll(() => nock.disableNetConnect());
 

--- a/packages/news/source/blockfolio.test.js
+++ b/packages/news/source/blockfolio.test.js
@@ -9,7 +9,7 @@ let subject;
 describe("FeedService", async ({ assert, afterEach, beforeEach, it, nock }) => {
 	beforeEach(() => (subject = new Blockfolio(new Request())));
 
-	afterEach(() => nock.cleanAll());
+
 
 	it("should retrieve the feed and findByCoin it", async () => {
 		nock.fake("https://news.payvo.com")

--- a/packages/news/source/blockfolio.test.js
+++ b/packages/news/source/blockfolio.test.js
@@ -9,8 +9,6 @@ let subject;
 describe("FeedService", async ({ assert, afterEach, beforeEach, it, nock }) => {
 	beforeEach(() => (subject = new Blockfolio(new Request())));
 
-
-
 	it("should retrieve the feed and findByCoin it", async () => {
 		nock.fake("https://news.payvo.com")
 			.get("/api")

--- a/packages/profiles/test/integration/ark.musig.registration.test.js
+++ b/packages/profiles/test/integration/ark.musig.registration.test.js
@@ -48,8 +48,6 @@ describe("ARK MuSig Registration", ({ assert, afterEach, beforeEach, it, nock })
 	});
 
 	afterEach((context) => {
-		nock.cleanAll();
-
 		context.resetServerResponseMocks();
 	});
 

--- a/packages/profiles/test/integration/lsk.musig.registration.test.js
+++ b/packages/profiles/test/integration/lsk.musig.registration.test.js
@@ -36,8 +36,6 @@ describe("LSK MuSig Registration", ({ assert, afterEach, beforeEach, each, it, n
 	});
 
 	afterEach((context) => {
-		nock.cleanAll();
-
 		context.resetServerResponseMocks();
 	});
 

--- a/packages/test/source/describe.ts
+++ b/packages/test/source/describe.ts
@@ -3,7 +3,7 @@ import { z as zod } from "zod";
 
 import { assert } from "./assert.js";
 import { eachSuite } from "./each.js";
-import { runHook, runHookWithClean } from "./hooks.js";
+import { runHook } from "./hooks.js";
 import { nock } from "./nock.js";
 import { loader } from "./loader.js";
 import { Mockery } from "./mockery.js";
@@ -12,9 +12,11 @@ type ContextFunction = () => Context;
 type ContextPromise = () => Promise<Context>;
 
 const runSuite = (suite: Test, callback: Function): void => {
+	suite.after.each(() => nock.cleanAll());
+
 	callback({
-		afterAll: async (callback_: Function) => suite.after(runHookWithClean(callback_)),
-		afterEach: async (callback_: Function) => suite.after.each(runHookWithClean(callback_)),
+		afterAll: async (callback_: Function) => suite.after(runHook(callback_)),
+		afterEach: async (callback_: Function) => suite.after.each(runHook(callback_)),
 		assert,
 		beforeAll: async (callback_: Function) => suite.before(runHook(callback_)),
 		beforeEach: async (callback_: Function) => suite.before.each(runHook(callback_)),

--- a/packages/test/source/describe.ts
+++ b/packages/test/source/describe.ts
@@ -3,7 +3,7 @@ import { z as zod } from "zod";
 
 import { assert } from "./assert.js";
 import { eachSuite } from "./each.js";
-import { runHook } from "./hooks.js";
+import { runHook, runHookWithClean } from "./hooks.js";
 import { nock } from "./nock.js";
 import { loader } from "./loader.js";
 import { Mockery } from "./mockery.js";
@@ -13,8 +13,8 @@ type ContextPromise = () => Promise<Context>;
 
 const runSuite = (suite: Test, callback: Function): void => {
 	callback({
-		afterAll: async (callback_: Function) => suite.after(runHook(callback_)),
-		afterEach: async (callback_: Function) => suite.after.each(runHook(callback_)),
+		afterAll: async (callback_: Function) => suite.after(runHookWithClean(callback_)),
+		afterEach: async (callback_: Function) => suite.after.each(runHookWithClean(callback_)),
 		assert,
 		beforeAll: async (callback_: Function) => suite.before(runHook(callback_)),
 		beforeEach: async (callback_: Function) => suite.before.each(runHook(callback_)),

--- a/packages/test/source/hooks.ts
+++ b/packages/test/source/hooks.ts
@@ -1,20 +1,9 @@
 import { bgRed, bold, white } from "kleur";
 import { Context, test } from "uvu";
-import { nock } from "./nock.js";
 
 export const runHook = (callback: Function) => async (context: Context) => {
 	try {
 		await callback(context);
-	} catch (error) {
-		console.log(bold(bgRed(white(error.stack))));
-	}
-};
-
-export const runHookWithClean = (callback: Function) => async (context: Context) => {
-	try {
-		await callback(context);
-
-		nock.cleanAll();
 	} catch (error) {
 		console.log(bold(bgRed(white(error.stack))));
 	}

--- a/packages/test/source/hooks.ts
+++ b/packages/test/source/hooks.ts
@@ -1,9 +1,20 @@
 import { bgRed, bold, white } from "kleur";
 import { Context, test } from "uvu";
+import { nock } from "./nock.js";
 
 export const runHook = (callback: Function) => async (context: Context) => {
 	try {
 		await callback(context);
+	} catch (error) {
+		console.log(bold(bgRed(white(error.stack))));
+	}
+};
+
+export const runHookWithClean = (callback: Function) => async (context: Context) => {
+	try {
+		await callback(context);
+
+		nock.cleanAll();
 	} catch (error) {
 		console.log(bold(bgRed(white(error.stack))));
 	}

--- a/packages/xlm/source/client.service.test.js
+++ b/packages/xlm/source/client.service.test.js
@@ -28,7 +28,7 @@ describe("ClientService", async ({ beforeAll, afterEach, it, assert }) => {
 		});
 	});
 
-	afterEach(() => nock.cleanAll());
+
 
 	it("#transaction", async () => {
 		nock.fake("https://horizon-testnet.stellar.org")

--- a/packages/xlm/source/client.service.test.js
+++ b/packages/xlm/source/client.service.test.js
@@ -28,8 +28,6 @@ describe("ClientService", async ({ beforeAll, afterEach, it, assert }) => {
 		});
 	});
 
-
-
 	it("#transaction", async () => {
 		nock.fake("https://horizon-testnet.stellar.org")
 			.get("/transactions/264226cb06af3b86299031884175155e67a02e0a8ad0b3ab3a88b409a8c09d5c")

--- a/packages/xlm/source/transaction.service.test.js
+++ b/packages/xlm/source/transaction.service.test.js
@@ -32,8 +32,6 @@ describe("TransactionService", async ({ beforeAll, afterEach, it, assert }) => {
 		});
 	});
 
-
-
 	it("#transfer should succeed", async () => {
 		nock.fake("https://horizon-testnet.stellar.org")
 			.get("/accounts/GCGYSPQBSQCJKNDXDISBSXAM3THK7MACUVZGEMXF6XRZCPGAWCUGXVNC")

--- a/packages/xlm/source/transaction.service.test.js
+++ b/packages/xlm/source/transaction.service.test.js
@@ -32,7 +32,7 @@ describe("TransactionService", async ({ beforeAll, afterEach, it, assert }) => {
 		});
 	});
 
-	afterEach(() => nock.cleanAll());
+
 
 	it("#transfer should succeed", async () => {
 		nock.fake("https://horizon-testnet.stellar.org")

--- a/packages/zil/source/client.service.test.js
+++ b/packages/zil/source/client.service.test.js
@@ -27,8 +27,6 @@ describe("ClientService", async ({ assert, afterEach, beforeEach, it, loader }) 
 		});
 	});
 
-
-
 	it("should retrieve a transaction", async () => {
 		nock.fake(/.+/).post("/").reply(200, loader.json(`test/fixtures/client/transaction.json`));
 

--- a/packages/zil/source/client.service.test.js
+++ b/packages/zil/source/client.service.test.js
@@ -27,7 +27,7 @@ describe("ClientService", async ({ assert, afterEach, beforeEach, it, loader }) 
 		});
 	});
 
-	afterEach(() => nock.cleanAll());
+
 
 	it("should retrieve a transaction", async () => {
 		nock.fake(/.+/).post("/").reply(200, loader.json(`test/fixtures/client/transaction.json`));


### PR DESCRIPTION
Ensure that we always clean the nock state before running a new test. Saves the hassle of thinking about calling this manually. Will probably cause a bunch of tests to fail because of a brittle setup, fixing them one by one.