### PR TITLE
test(neo): consistent use of `context`

### DIFF
--- a/packages/neo/source/address.service.test.js
+++ b/packages/neo/source/address.service.test.js
@@ -3,15 +3,13 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { AddressService } from "./address.service";
 
-let subject;
-
 describe("AddressService", async ({ beforeEach, it, assert }) => {
-	beforeEach(async () => {
-		subject = await createService(AddressService);
+	beforeEach(async (context) => {
+		context.subject = await createService(AddressService);
 	});
 
-	it("should generate an output from a mnemonic", async () => {
-		const result = await subject.fromMnemonic(identity.mnemonic);
+	it("should generate an output from a mnemonic", async (context) => {
+		const result = await context.subject.fromMnemonic(identity.mnemonic);
 
 		assert.equal(result, {
 			address: "APPJtAkysCKBssD5EJzEpakntNk81nR7X2",
@@ -19,8 +17,8 @@ describe("AddressService", async ({ beforeEach, it, assert }) => {
 		});
 	});
 
-	it("should generate an output from a publicKey", async () => {
-		const result = await subject.fromPublicKey(identity.publicKey);
+	it("should generate an output from a publicKey", async (context) => {
+		const result = await context.subject.fromPublicKey(identity.publicKey);
 
 		assert.equal(result, {
 			address: "APPJtAkysCKBssD5EJzEpakntNk81nR7X2",
@@ -28,8 +26,8 @@ describe("AddressService", async ({ beforeEach, it, assert }) => {
 		});
 	});
 
-	it("should generate an output from a privateKey", async () => {
-		const result = await subject.fromPrivateKey(identity.privateKey);
+	it("should generate an output from a privateKey", async (context) => {
+		const result = await context.subject.fromPrivateKey(identity.privateKey);
 
 		assert.equal(result, {
 			address: "APPJtAkysCKBssD5EJzEpakntNk81nR7X2",
@@ -37,8 +35,8 @@ describe("AddressService", async ({ beforeEach, it, assert }) => {
 		});
 	});
 
-	it("should generate an output from a wif", async () => {
-		const result = await subject.fromWIF(identity.wif);
+	it("should generate an output from a wif", async (context) => {
+		const result = await context.subject.fromWIF(identity.wif);
 
 		assert.equal(result, {
 			address: "APPJtAkysCKBssD5EJzEpakntNk81nR7X2",
@@ -46,8 +44,8 @@ describe("AddressService", async ({ beforeEach, it, assert }) => {
 		});
 	});
 
-	it("should validate an address", async () => {
-		assert.true(await subject.validate("AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX"));
-		assert.false(await subject.validate("ABC"));
+	it("should validate an address", async (context) => {
+		assert.true(await context.subject.validate("AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX"));
+		assert.false(await context.subject.validate("ABC"));
 	});
 });

--- a/packages/neo/source/key-pair.service.test.js
+++ b/packages/neo/source/key-pair.service.test.js
@@ -3,29 +3,27 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { KeyPairService } from "./key-pair.service";
 
-let subject;
-
 describe("KeyPairService", async ({ beforeEach, it, assert }) => {
-	beforeEach(async () => {
-		subject = await createService(KeyPairService);
+	beforeEach(async (context) => {
+		context.subject = await createService(KeyPairService);
 	});
 
-	it("should generate an output from a mnemonic", async () => {
-		assert.equal(await subject.fromMnemonic(identity.mnemonic), {
+	it("should generate an output from a mnemonic", async (context) => {
+		assert.equal(await context.subject.fromMnemonic(identity.mnemonic), {
 			privateKey: identity.privateKey,
 			publicKey: identity.publicKey,
 		});
 	});
 
-	it("should generate an output from a privateKey", async () => {
-		assert.equal(await subject.fromPrivateKey(identity.privateKey), {
+	it("should generate an output from a privateKey", async (context) => {
+		assert.equal(await context.subject.fromPrivateKey(identity.privateKey), {
 			privateKey: identity.privateKey,
 			publicKey: identity.publicKey,
 		});
 	});
 
-	it("should generate an output from a wif", async () => {
-		assert.equal(await subject.fromWIF(identity.wif), {
+	it("should generate an output from a wif", async (context) => {
+		assert.equal(await context.subject.fromWIF(identity.wif), {
 			privateKey: identity.privateKey,
 			publicKey: identity.publicKey,
 		});

--- a/packages/neo/source/link.service.test.js
+++ b/packages/neo/source/link.service.test.js
@@ -3,22 +3,20 @@ import { Services } from "@payvo/sdk";
 
 import { createService } from "../test/mocking";
 
-let subject;
-
 describe("LinkService", async ({ beforeAll, it, assert }) => {
-	beforeAll(async () => {
-		subject = await createService(Services.AbstractLinkService);
+	beforeAll(async (context) => {
+		context.subject = await createService(Services.AbstractLinkService);
 	});
 
-	it("should generate a link for a block", async () => {
-		assert.is(subject.block("id"), "https://neoscan-testnet.io/block/height/id");
+	it("should generate a link for a block", (context) => {
+		assert.is(context.subject.block("id"), "https://neoscan-testnet.io/block/height/id");
 	});
 
-	it("should generate a link for a transaction", async () => {
-		assert.is(subject.transaction("id"), "https://neoscan-testnet.io/tx/id");
+	it("should generate a link for a transaction", (context) => {
+		assert.is(context.subject.transaction("id"), "https://neoscan-testnet.io/tx/id");
 	});
 
-	it("should generate a link for a wallet", async () => {
-		assert.is(subject.wallet("id"), "https://neoscan-testnet.io/address/id");
+	it("should generate a link for a wallet", (context) => {
+		assert.is(context.subject.wallet("id"), "https://neoscan-testnet.io/address/id");
 	});
 });

--- a/packages/neo/source/message.service.test.js
+++ b/packages/neo/source/message.service.test.js
@@ -5,15 +5,13 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { MessageService } from "./message.service";
 
-let subject;
-
 describe("MessageService", async ({ beforeEach, it, assert }) => {
-	beforeEach(async () => {
-		subject = await createService(MessageService);
+	beforeEach(async (context) => {
+		context.subject = await createService(MessageService);
 	});
 
-	it("should sign and verify a message", async () => {
-		const result = await subject.sign({
+	it("should sign and verify a message", async (context) => {
+		const result = await context.subject.sign({
 			message: "Hello World",
 			signatory: new Signatories.Signatory(
 				new Signatories.PrivateKeySignatory({
@@ -23,6 +21,6 @@ describe("MessageService", async ({ beforeEach, it, assert }) => {
 			),
 		});
 
-		assert.true(await subject.verify(result));
+		assert.true(await context.subject.verify(result));
 	});
 });

--- a/packages/neo/source/private-key.service.test.js
+++ b/packages/neo/source/private-key.service.test.js
@@ -3,21 +3,19 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { PrivateKeyService } from "./private-key.service";
 
-let subject;
-
 describe("PrivateKeyService", async ({ beforeEach, it, assert }) => {
-	beforeEach(async () => {
-		subject = await createService(PrivateKeyService);
+	beforeEach(async (context) => {
+		context.subject = await createService(PrivateKeyService);
 	});
 
-	it("should generate an output from a mnemonic", async () => {
-		const result = await subject.fromMnemonic(identity.mnemonic);
+	it("should generate an output from a mnemonic", async (context) => {
+		const result = await context.subject.fromMnemonic(identity.mnemonic);
 
 		assert.equal(result, { privateKey: identity.privateKey });
 	});
 
-	it("should generate an output from a wif", async () => {
-		const result = await subject.fromWIF(identity.wif);
+	it("should generate an output from a wif", async (context) => {
+		const result = await context.subject.fromWIF(identity.wif);
 
 		assert.equal(result, { privateKey: identity.privateKey });
 	});

--- a/packages/neo/source/public-key.service.test.js
+++ b/packages/neo/source/public-key.service.test.js
@@ -3,21 +3,19 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { PublicKeyService } from "./public-key.service";
 
-let subject;
-
 describe("PublicKeyService", async ({ beforeEach, assert, it }) => {
-	beforeEach(async () => {
-		subject = await createService(PublicKeyService);
+	beforeEach(async (context) => {
+		context.subject = await createService(PublicKeyService);
 	});
 
-	it("should generate an output from a mnemonic", async () => {
-		const result = await subject.fromMnemonic(identity.mnemonic);
+	it("should generate an output from a mnemonic", async (context) => {
+		const result = await context.subject.fromMnemonic(identity.mnemonic);
 
 		assert.equal(result, { publicKey: identity.publicKey });
 	});
 
-	it("should generate an output from a wif", async () => {
-		const result = await subject.fromWIF(identity.wif);
+	it("should generate an output from a wif", async (context) => {
+		const result = await context.subject.fromWIF(identity.wif);
 
 		assert.equal(result, { publicKey: identity.publicKey });
 	});

--- a/packages/neo/source/signed-transaction.dto.test.js
+++ b/packages/neo/source/signed-transaction.dto.test.js
@@ -4,13 +4,11 @@ import { DateTime } from "@payvo/sdk-intl";
 import { createService } from "../test/mocking";
 import { SignedTransactionData } from "./signed-transaction.dto";
 
-let subject;
-
 describe("SignedTransactionData", async ({ beforeEach, it, assert }) => {
-	beforeEach(async () => {
-		subject = await createService(SignedTransactionData);
+	beforeEach(async (context) => {
+		context.subject = await createService(SignedTransactionData);
 
-		subject.configure(
+		context.subject.configure(
 			"3e3817fd0c35bc36674f3874c2953fa3e35877cbcdb44a08bdc6083dbd39d572",
 			{
 				timestamp: "1970-01-01T00:00:00.000Z",
@@ -19,7 +17,7 @@ describe("SignedTransactionData", async ({ beforeEach, it, assert }) => {
 		);
 	});
 
-	it("should have timestamp", () => {
-		assert.true(DateTime.make(0).isSame(subject.timestamp()));
+	it("should have timestamp", (context) => {
+		assert.true(DateTime.make(0).isSame(context.subject.timestamp()));
 	});
 });

--- a/packages/neo/source/transaction.dto.test.js
+++ b/packages/neo/source/transaction.dto.test.js
@@ -5,12 +5,10 @@ import { BigNumber } from "@payvo/sdk-helpers";
 import { createService } from "../test/mocking";
 import { ConfirmedTransactionData } from "./confirmed-transaction.dto";
 
-let subject;
-
 describe("ConfirmedTransactionData", async ({ assert, it, beforeEach }) => {
-	beforeEach(async () => {
-		subject = await createService(ConfirmedTransactionData);
-		subject.configure({
+	beforeEach(async (context) => {
+		context.subject = await createService(ConfirmedTransactionData);
+		context.subject.configure({
 			txid: "718bc4cfc50c361a8afe032e2c170dfebadce16ea72228a57634413b62b7cf24",
 			time: 1588930966,
 			block_height: 4259222,
@@ -21,16 +19,16 @@ describe("ConfirmedTransactionData", async ({ assert, it, beforeEach }) => {
 		});
 	});
 
-	it("should succeed", async () => {
-		assert.instance(subject, ConfirmedTransactionData);
-		assert.is(subject.id(), "718bc4cfc50c361a8afe032e2c170dfebadce16ea72228a57634413b62b7cf24");
-		assert.is(subject.type(), "transfer");
-		assert.instance(subject.timestamp(), DateTime);
-		assert.equal(subject.confirmations(), BigNumber.ZERO);
-		assert.is(subject.sender(), "AStJyBXGGBK6bwrRfRUHSjp993PB5C9QgF");
-		assert.is(subject.recipient(), "Ab9QkPeMzx7ehptvjbjHviAXUfdhAmEAUF");
-		assert.equal(subject.amount(), BigNumber.make(1));
-		assert.equal(subject.fee(), BigNumber.ZERO);
-		assert.undefined(subject.memo());
+	it("should succeed", async (context) => {
+		assert.instance(context.subject, ConfirmedTransactionData);
+		assert.is(context.subject.id(), "718bc4cfc50c361a8afe032e2c170dfebadce16ea72228a57634413b62b7cf24");
+		assert.is(context.subject.type(), "transfer");
+		assert.instance(context.subject.timestamp(), DateTime);
+		assert.equal(context.subject.confirmations(), BigNumber.ZERO);
+		assert.is(context.subject.sender(), "AStJyBXGGBK6bwrRfRUHSjp993PB5C9QgF");
+		assert.is(context.subject.recipient(), "Ab9QkPeMzx7ehptvjbjHviAXUfdhAmEAUF");
+		assert.equal(context.subject.amount(), BigNumber.make(1));
+		assert.equal(context.subject.fee(), BigNumber.ZERO);
+		assert.undefined(context.subject.memo());
 	});
 });

--- a/packages/neo/source/wallet.dto.test.js
+++ b/packages/neo/source/wallet.dto.test.js
@@ -5,62 +5,60 @@ import Fixture from "../test/fixtures/client/wallet.json";
 import { WalletData } from "./wallet.dto";
 import { createService } from "../test/mocking";
 
-let subject;
-
 describe("WalletData", async ({ beforeAll, it, assert }) => {
-	beforeAll(async () => {
-		subject = (await createService(WalletData)).fill(Fixture);
+	beforeAll(async (context) => {
+		context.subject = (await createService(WalletData)).fill(Fixture);
 	});
 
-	it("should have an address", () => {
-		assert.is(subject.address(), "AStJyBXGGBK6bwrRfRUHSjp993PB5C9QgF");
+	it("should have an address", (context) => {
+		assert.is(context.subject.address(), "AStJyBXGGBK6bwrRfRUHSjp993PB5C9QgF");
 	});
 
-	it("should have a publicKey", () => {
-		assert.throws(() => subject.publicKey(), "not implemented");
+	it("should have a publicKey", (context) => {
+		assert.throws(() => context.subject.publicKey(), "not implemented");
 	});
 
-	it("should have a balance", () => {
-		assert.equal(subject.balance().available, BigNumber.make(3050000));
+	it("should have a balance", (context) => {
+		assert.equal(context.subject.balance().available, BigNumber.make(3050000));
 	});
 
-	it("should have a nonce", () => {
-		assert.equal(subject.nonce(), BigNumber.make(24242));
+	it("should have a nonce", (context) => {
+		assert.equal(context.subject.nonce(), BigNumber.make(24242));
 	});
 
-	it("should have a second public key", () => {
-		assert.throws(() => subject.secondPublicKey(), "not implemented");
+	it("should have a second public key", (context) => {
+		assert.throws(() => context.subject.secondPublicKey(), "not implemented");
 	});
 
-	it("should have a username", () => {
-		assert.throws(() => subject.username(), "not implemented");
+	it("should have a username", (context) => {
+		assert.throws(() => context.subject.username(), "not implemented");
 	});
 
-	it("should have a rank", () => {
-		assert.throws(() => subject.rank(), "not implemented");
+	it("should have a rank", (context) => {
+		assert.throws(() => context.subject.rank(), "not implemented");
 	});
 
-	it("should have votes", () => {
-		assert.throws(() => subject.votes(), "not implemented");
+	it("should have votes", (context) => {
+		assert.throws(() => context.subject.votes(), "not implemented");
 	});
 
-	it("should have multisignature data", () => {
-		assert.throws(() => subject.multiSignature(), "not implemented");
+	it("should have multisignature data", (context) => {
+		assert.throws(() => context.subject.multiSignature(), "not implemented");
 	});
 
-	it("should have a method to know if wallet is multisignature", () => {
-		assert.false(subject.isMultiSignature());
+	it("should have a method to know if wallet is multisignature", (context) => {
+		assert.false(context.subject.isMultiSignature());
 	});
 
-	it("should have a method to know if wallet is delegate", () => {
-		assert.false(subject.isDelegate());
+	it("should have a method to know if wallet is delegate", (context) => {
+		assert.false(context.subject.isDelegate());
 	});
 
-	it("should have a method to know if wallet is second signature", () => {
-		assert.false(subject.isSecondSignature());
+	it("should have a method to know if wallet is second signature", (context) => {
+		assert.false(context.subject.isSecondSignature());
 	});
 
-	it("should have a method to know if wallet is a resigned delegate", () => {
-		assert.false(subject.isResignedDelegate());
+	it("should have a method to know if wallet is a resigned delegate", (context) => {
+		assert.false(context.subject.isResignedDelegate());
 	});
 });

--- a/packages/neo/source/wif.service.test.js
+++ b/packages/neo/source/wif.service.test.js
@@ -3,15 +3,13 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { WIFService } from "./wif.service";
 
-let subject;
-
 describe("WIFService", async ({ beforeEach, it, assert }) => {
-	beforeEach(async () => {
-		subject = await createService(WIFService);
+	beforeEach(async (context) => {
+		context.subject = await createService(WIFService);
 	});
 
-	it("should generate an output from a mnemonic", async () => {
-		const result = await subject.fromMnemonic(identity.mnemonic);
+	it("should generate an output from a mnemonic", async (context) => {
+		const result = await context.subject.fromMnemonic(identity.mnemonic);
 
 		assert.equal(result, { wif: identity.wif });
 	});


### PR DESCRIPTION
Part of https://github.com/PayvoHQ/sdk/issues/466