### PR TITLE
test(avax): consistent use of `context`

### DIFF
--- a/packages/avax/source/address.service.test.js
+++ b/packages/avax/source/address.service.test.js
@@ -3,29 +3,27 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { AddressService } from "./address.service";
 
-let subject;
-
 describe("AddressService", async ({ assert, beforeEach, it }) => {
-	beforeEach(async () => {
-		subject = await createService(AddressService);
+	beforeEach(async (context) => {
+		context.subject = await createService(AddressService);
 	});
 
-	it("should generate an output from a mnemonic", async () => {
-		assert.equal(await subject.fromMnemonic(identity.mnemonic), {
+	it("should generate an output from a mnemonic", async (context) => {
+		assert.equal(await context.subject.fromMnemonic(identity.mnemonic), {
 			address: "X-fuji1rusf9c2uwlqxg5crfrqr8xrt4r49yk6rskehvm",
 			path: "m/44'/9000'/0'/0/0",
 			type: "bip44",
 		});
 	});
 
-	it("should fail to generate an output from a privateKey", async () => {
-		assert.equal(await subject.fromPrivateKey(identity.privateKey), {
+	it("should fail to generate an output from a privateKey", async (context) => {
+		assert.equal(await context.subject.fromPrivateKey(identity.privateKey), {
 			type: "bip44",
 			address: identity.address,
 		});
 	});
 
-	it("should fail to validate an address", async () => {
-		assert.true(await subject.validate(identity.address));
+	it("should fail to validate an address", async (context) => {
+		assert.true(await context.subject.validate(identity.address));
 	});
 });

--- a/packages/avax/source/client.service.test.js
+++ b/packages/avax/source/client.service.test.js
@@ -7,11 +7,9 @@ import { SignedTransactionData } from "./signed-transaction.dto";
 import { ConfirmedTransactionData } from "./confirmed-transaction.dto";
 import { WalletData } from "./wallet.dto";
 
-let subject;
-
 describe("ClientService", async ({ assert, beforeAll, skip, it }) => {
-	beforeAll(async () => {
-		subject = await createService(ClientService, undefined, (container) => {
+	beforeAll(async (context) => {
+		context.subject = await createService(ClientService, undefined, (container) => {
 			container.constant(IoC.BindingType.Container, container);
 			container.constant(IoC.BindingType.DataTransferObjects, {
 				SignedTransactionData,
@@ -22,14 +20,14 @@ describe("ClientService", async ({ assert, beforeAll, skip, it }) => {
 		});
 	});
 
-	skip("should retrieve a single transaction", async () => {
-		const result = await subject.transaction("2qwe2tsgBZ5yqq6Qg2eTDPJ1tVVZZ9KoPLMDwurLTGTNpGMFr9");
+	skip("should retrieve a single transaction", async (context) => {
+		const result = await context.subject.transaction("2qwe2tsgBZ5yqq6Qg2eTDPJ1tVVZZ9KoPLMDwurLTGTNpGMFr9");
 
 		assert.instance(result, ConfirmedTransactionData);
 	});
 
-	skip("should retrieve a list of transactions", async () => {
-		const result = await subject.transactions({
+	skip("should retrieve a list of transactions", async (context) => {
+		const result = await context.subject.transactions({
 			identifiers: [
 				{
 					type: "address",
@@ -41,8 +39,8 @@ describe("ClientService", async ({ assert, beforeAll, skip, it }) => {
 		assert.instance(result, Collections.ConfirmedTransactionDataCollection);
 	});
 
-	skip("#wallet", async () => {
-		const result = await subject.wallet({
+	skip("#wallet", async (context) => {
+		const result = await context.subject.wallet({
 			type: "address",
 			value: "X-fuji1my5kqjufcshudkzu4xdt5rlqk99j9nwseclkwq",
 		});
@@ -50,7 +48,7 @@ describe("ClientService", async ({ assert, beforeAll, skip, it }) => {
 		assert.instance(result, WalletData);
 	});
 
-	skip("#delegates", async () => {
-		assert.instance(await subject.delegates(), Collections.WalletDataCollection);
+	skip("#delegates", async (context) => {
+		assert.instance(await context.subject.delegates(), Collections.WalletDataCollection);
 	});
 });

--- a/packages/avax/source/key-pair.service.test.js
+++ b/packages/avax/source/key-pair.service.test.js
@@ -3,23 +3,21 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { KeyPairService } from "./key-pair.service";
 
-let subject;
-
 describe("KeyPairService", async ({ assert, beforeEach, it }) => {
-	beforeEach(async () => {
-		subject = await createService(KeyPairService);
+	beforeEach(async (context) => {
+		context.subject = await createService(KeyPairService);
 	});
 
-	it("should generate an output from a mnemonic", async () => {
-		assert.equal(await subject.fromMnemonic(identity.mnemonic), {
+	it("should generate an output from a mnemonic", async (context) => {
+		assert.equal(await context.subject.fromMnemonic(identity.mnemonic), {
 			path: "m/44'/9000'/0'/0/0",
 			privateKey: "rC7DsPL1zKuPnwnqHSnShdXxeMReKWLBJgKcuJ1ZLUCUrzRni",
 			publicKey: "7qobgTQPiy3mH4tvjabDjapPVrh9Tnkb3tpn2yY37hsEyxaSjW",
 		});
 	});
 
-	it("should generate an output from a privateKey", async () => {
-		assert.equal(await subject.fromPrivateKey(identity.privateKey), {
+	it("should generate an output from a privateKey", async (context) => {
+		assert.equal(await context.subject.fromPrivateKey(identity.privateKey), {
 			publicKey: identity.publicKey,
 			privateKey: identity.privateKey,
 		});

--- a/packages/avax/source/link.service.test.js
+++ b/packages/avax/source/link.service.test.js
@@ -3,22 +3,20 @@ import { Services } from "@payvo/sdk";
 
 import { createService } from "../test/mocking";
 
-let subject;
-
 describe("LinkService", async ({ assert, beforeAll, it }) => {
-	beforeAll(async () => {
-		subject = await createService(Services.AbstractLinkService);
+	beforeAll(async (context) => {
+		context.subject = await createService(Services.AbstractLinkService);
 	});
 
-	it("should generate a link for a block", async () => {
-		assert.is(subject.block("id"), "https://explorer.avax-test.network/block/id");
+	it("should generate a link for a block", async (context) => {
+		assert.is(context.subject.block("id"), "https://explorer.avax-test.network/block/id");
 	});
 
-	it("should generate a link for a transaction", async () => {
-		assert.is(subject.transaction("id"), "https://explorer.avax-test.network/tx/id");
+	it("should generate a link for a transaction", async (context) => {
+		assert.is(context.subject.transaction("id"), "https://explorer.avax-test.network/tx/id");
 	});
 
-	it("should generate a link for a wallet", async () => {
-		assert.is(subject.wallet("id"), "https://explorer.avax-test.network/address/id");
+	it("should generate a link for a wallet", async (context) => {
+		assert.is(context.subject.wallet("id"), "https://explorer.avax-test.network/address/id");
 	});
 });

--- a/packages/avax/source/message.service.test.js
+++ b/packages/avax/source/message.service.test.js
@@ -5,15 +5,13 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { MessageService } from "./message.service";
 
-let subject;
-
 describe("MessageService", async ({ assert, beforeEach, it }) => {
-	beforeEach(async () => {
-		subject = await createService(MessageService);
+	beforeEach(async (context) => {
+		context.subject = await createService(MessageService);
 	});
 
-	it("should sign and verify a message", async () => {
-		const result = await subject.sign({
+	it("should sign and verify a message", async (context) => {
+		const result = await context.subject.sign({
 			message: "Hello World",
 			signatory: new Signatories.Signatory(
 				new Signatories.MnemonicSignatory({
@@ -25,6 +23,6 @@ describe("MessageService", async ({ assert, beforeEach, it }) => {
 			),
 		});
 
-		assert.true(await subject.verify(result));
+		assert.true(await context.subject.verify(result));
 	});
 });

--- a/packages/avax/source/private-key.service.test.js
+++ b/packages/avax/source/private-key.service.test.js
@@ -3,15 +3,13 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { PrivateKeyService } from "./private-key.service";
 
-let subject;
-
 describe("PrivateKeyService", async ({ assert, beforeEach, it }) => {
-	beforeEach(async () => {
-		subject = await createService(PrivateKeyService);
+	beforeEach(async (context) => {
+		context.subject = await createService(PrivateKeyService);
 	});
 
-	it("should generate an output from a mnemonic", async () => {
-		assert.equal(await subject.fromMnemonic(identity.mnemonic), {
+	it("should generate an output from a mnemonic", async (context) => {
+		assert.equal(await context.subject.fromMnemonic(identity.mnemonic), {
 			path: "m/44'/9000'/0'/0/0",
 			privateKey: "rC7DsPL1zKuPnwnqHSnShdXxeMReKWLBJgKcuJ1ZLUCUrzRni",
 		});

--- a/packages/avax/source/public-key.service.test.js
+++ b/packages/avax/source/public-key.service.test.js
@@ -3,15 +3,13 @@ import { identity } from "../test/fixtures/identity";
 import { createService } from "../test/mocking";
 import { PublicKeyService } from "./public-key.service";
 
-let subject;
-
 describe("PublicKeyService", async ({ assert, beforeEach, it }) => {
-	beforeEach(async () => {
-		subject = await createService(PublicKeyService);
+	beforeEach(async (context) => {
+		context.subject = await createService(PublicKeyService);
 	});
 
-	it("should generate an output from a mnemonic", async () => {
-		assert.equal(await subject.fromMnemonic(identity.mnemonic), {
+	it("should generate an output from a mnemonic", async (context) => {
+		assert.equal(await context.subject.fromMnemonic(identity.mnemonic), {
 			path: "m/44'/9000'/0'/0/0",
 			publicKey: "7qobgTQPiy3mH4tvjabDjapPVrh9Tnkb3tpn2yY37hsEyxaSjW",
 		});

--- a/packages/avax/source/signed-transaction.dto.test.js
+++ b/packages/avax/source/signed-transaction.dto.test.js
@@ -5,13 +5,11 @@ import { createService } from "../test/mocking";
 import { SignedTransactionData } from "./signed-transaction.dto";
 import { BigNumber } from "@payvo/sdk-helpers";
 
-let subject;
-
 describe("SignedTransactionData", async ({ assert, beforeEach, it }) => {
-	beforeEach(async () => {
-		subject = await createService(SignedTransactionData);
+	beforeEach(async (context) => {
+		context.subject = await createService(SignedTransactionData);
 
-		subject.configure(
+		context.subject.configure(
 			"3e3817fd0c35bc36674f3874c2953fa3e35877cbcdb44a08bdc6083dbd39d572",
 			{
 				id: "3e3817fd0c35bc36674f3874c2953fa3e35877cbcdb44a08bdc6083dbd39d572",
@@ -25,23 +23,23 @@ describe("SignedTransactionData", async ({ assert, beforeEach, it }) => {
 		);
 	});
 
-	it("should have a sender", () => {
-		assert.is(subject.sender(), "0208e6835a8f020cfad439c059b89addc1ce21f8cab0af6e6957e22d3720bff8a4");
+	it("should have a sender", (context) => {
+		assert.is(context.subject.sender(), "0208e6835a8f020cfad439c059b89addc1ce21f8cab0af6e6957e22d3720bff8a4");
 	});
 
-	it("should have a recipient", () => {
-		assert.is(subject.recipient(), "D6Z26L69gdk9qYmTv5uzk3uGepigtHY4ax");
+	it("should have a recipient", (context) => {
+		assert.is(context.subject.recipient(), "D6Z26L69gdk9qYmTv5uzk3uGepigtHY4ax");
 	});
 
-	it("should have an amount", () => {
-		assert.is(subject.amount().toHuman(), 125);
+	it("should have an amount", (context) => {
+		assert.is(context.subject.amount().toHuman(), 125);
 	});
 
-	it("should have a fee", () => {
-		assert.equal(subject.fee(), BigNumber.ZERO);
+	it("should have a fee", (context) => {
+		assert.equal(context.subject.fee(), BigNumber.ZERO);
 	});
 
-	it("should have a timestamp", () => {
-		assert.equal(subject.timestamp(), DateTime.make(0));
+	it("should have a timestamp", (context) => {
+		assert.equal(context.subject.timestamp(), DateTime.make(0));
 	});
 });

--- a/packages/avax/source/transaction.service.test.js
+++ b/packages/avax/source/transaction.service.test.js
@@ -12,11 +12,9 @@ import { SignedTransactionData } from "./signed-transaction.dto";
 import { ConfirmedTransactionData } from "./confirmed-transaction.dto";
 import { WalletData } from "./wallet.dto";
 
-let subject;
-
 describe("TransactionService", async ({ assert, beforeAll, skip }) => {
-	beforeAll(async () => {
-		subject = await createService(TransactionService, undefined, (container) => {
+	beforeAll(async (context) => {
+		context.subject = await createService(TransactionService, undefined, (container) => {
 			container.constant(IoC.BindingType.Container, container);
 			container.singleton(IoC.BindingType.ClientService, ClientService);
 			container.singleton(IoC.BindingType.AddressService, AddressService);
@@ -31,8 +29,8 @@ describe("TransactionService", async ({ assert, beforeAll, skip }) => {
 		});
 	});
 
-	skip("#transfer", async () => {
-		const result = await subject.transfer({
+	skip("#transfer", async (context) => {
+		const result = await context.subject.transfer({
 			signatory: new Signatories.Signatory(
 				new Signatories.MnemonicSignatory({
 					signingKey: identity.mnemonic,


### PR DESCRIPTION
Part of https://github.com/PayvoHQ/sdk/issues/466