### PR TITLE
refactor(test): add types for `describe` methods

### DIFF
--- a/packages/test/source/describe.ts
+++ b/packages/test/source/describe.ts
@@ -81,8 +81,11 @@ const runSuite = (suite: Test, callback: CallbackFunction, dataset?: unknown): v
 
 export const describe = (title: string, callback: CallbackFunction): void => runSuite(suite(title), callback);
 
-export const describeWithContext = (title: string, context: Context | ContextFunction, callback: CallbackFunction): void =>
-	runSuite(suite(title, typeof context === "function" ? context() : context), callback);
+export const describeWithContext = (
+	title: string,
+	context: Context | ContextFunction,
+	callback: CallbackFunction,
+): void => runSuite(suite(title, typeof context === "function" ? context() : context), callback);
 
 export const describeEach = (title: string, callback: CallbackFunction, datasets: unknown[]): void => {
 	for (const dataset of datasets) {


### PR DESCRIPTION
When writing tests there'll now be autocompletion for the destructured properties.