### PR TITLE
refactor(cryptography): create abstractions for `bech32` and `secp256k1`

### DIFF
--- a/packages/ark/source/crypto/hash.ts
+++ b/packages/ark/source/crypto/hash.ts
@@ -1,4 +1,4 @@
-import { secp256k1 } from "bcrypto";
+import { secp256k1 } from "@payvo/sdk-cryptography";
 
 import { IKeyPair } from "./interfaces";
 

--- a/packages/cryptography/source/bech32.ts
+++ b/packages/cryptography/source/bech32.ts
@@ -1,0 +1,17 @@
+import { bech32 as base, Decoded } from "bech32";
+
+class Bech32 {
+	public encode(prefix: string, words: ArrayLike<number>): string {
+		return base.encode(prefix, words);
+	}
+
+	public decode(value: string, limit?: number | undefined): Decoded {
+		return base.decode(value, limit);
+	}
+
+	public toWords(bytes: ArrayLike<number>): number[] {
+		return base.toWords(bytes);
+	}
+}
+
+export const bech32 = new Bech32();

--- a/packages/cryptography/source/index.ts
+++ b/packages/cryptography/source/index.ts
@@ -1,9 +1,9 @@
-// TODO: temporarly disabled because the export causes issues for environments like electron.
 // export * from "./argon2.js";
-export * from "./base58.js";
 export * from "./base58-check.js";
+export * from "./base58.js";
 export * from "./base64.js";
 export * from "./bcrypt.js";
+export * from "./bech32.js";
 export * from "./bip32.js";
 export * from "./bip39.js";
 export * from "./bip44.js";
@@ -11,7 +11,6 @@ export * from "./buffoon.js";
 export * from "./hash.js";
 export * from "./hdkey.js";
 export * from "./pbkdf2.js";
+export * from "./secp256k1.js";
 export * from "./uuid.js";
 export * from "./wif.js";
-export { secp256k1 } from "bcrypto";
-export { bech32 } from "bech32";

--- a/packages/cryptography/source/secp256k1.ts
+++ b/packages/cryptography/source/secp256k1.ts
@@ -1,0 +1,45 @@
+import { secp256k1 as bcrypto } from "bcrypto";
+
+class Secp256k1 {
+	public publicKeyCreate(privateKey: Buffer, compressed: boolean): Buffer {
+		return bcrypto.publicKeyCreate(privateKey, compressed);
+	}
+
+	public publicKeyVerify(publicKey: Buffer): boolean {
+		return bcrypto.publicKeyVerify(publicKey);
+	}
+
+	public publicKeyCombine(publicKeys: Buffer[]): Buffer {
+		return bcrypto.publicKeyCombine(publicKeys);
+	}
+
+	public signatureImport(signature: Buffer): Buffer {
+		return bcrypto.signatureImport(signature);
+	}
+
+	public signatureExport(signature: Buffer): Buffer {
+		return bcrypto.signatureExport(signature);
+	}
+
+	public isLowS(signature: Buffer): boolean {
+		return bcrypto.isLowS(signature);
+	}
+
+	public sign(hash: Buffer, privateKey: Buffer): Buffer {
+		return bcrypto.sign(hash, privateKey);
+	}
+
+	public verify(hash: Buffer, signature: Buffer, publicKey: Buffer): boolean {
+		return bcrypto.verify(hash, signature, publicKey);
+	}
+
+	public schnorrSign(hash: Buffer, privateKey: Buffer): Buffer {
+		return bcrypto.schnorrSign(hash, privateKey);
+	}
+
+	public schnorrVerify(hash: Buffer, signature: Buffer, publicKey: Buffer): boolean {
+		return bcrypto.schnorrVerify(hash, signature, publicKey);
+	}
+}
+
+export const secp256k1 = new Secp256k1();


### PR DESCRIPTION
Signed-off-by: Brian Faust <hello@basecode.sh>
