### PR TITLE
refactor(cryptography): use `@noble/hashes` for hashing

### DIFF
--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -20,6 +20,7 @@
 		"test:watch": "watchlist source -- pnpm run test"
 	},
 	"dependencies": {
+		"@noble/hashes": "^0.4.1",
 		"argon2-browser": "^1.18.0",
 		"bcryptjs": "^2.4.3",
 		"bcrypto": "^5.4.0",

--- a/packages/cryptography/source/hash.test.ts
+++ b/packages/cryptography/source/hash.test.ts
@@ -2,30 +2,15 @@ import { describe } from "@payvo/sdk-test";
 
 import { Hash } from "./hash";
 
-describe("Hash", ({ assert, it, nock, loader }) => {
+describe("Hash", ({ assert, it }) => {
 	it("should compute a RIPEMD160 hash for the given value", () => {
 		assert.is(Hash.ripemd160("Hello World").toString("hex"), "a830d7beb04eb7549ce990fb7dc962e499a27230");
 	});
 
-	it("should compute a SHA1 hash for the given value", () => {
-		assert.is(Hash.sha1("Hello World").toString("hex"), "0a4d55a8d778e5022fab701977c5d840bbc486d0");
-	});
-
-	it("should compute a SHA256 hash for the given value", () => {
+	it("should compute a SHA256 hash for the given value", async () => {
 		assert.is(
 			Hash.sha256("Hello World").toString("hex"),
 			"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e",
-		);
-	});
-
-	it("should compute a HASH160 hash for the given value", () => {
-		assert.is(Hash.hash160("Hello World").toString("hex"), "bdfb69557966d026975bebe914692bf08490d8ca");
-	});
-
-	it("should compute a HASH256 hash for the given value", () => {
-		assert.is(
-			Hash.hash256("Hello World").toString("hex"),
-			"42a873ac3abd02122d27e80486c6fa1ef78694e8505fcec9cbcc8a7728ba8949",
 		);
 	});
 });

--- a/packages/cryptography/source/hash.ts
+++ b/packages/cryptography/source/hash.ts
@@ -1,97 +1,15 @@
-import { Hash160, Hash256, RIPEMD160, SHA1, SHA256 } from "bcrypto";
+import { sha256 } from "@noble/hashes/lib/sha256";
+import { ripemd160 } from "@noble/hashes/lib/ripemd160";
 
-/**
- * Implements a variety of hashing functions that are required to work with
- * most blockchains, especially ones that follow the Bitcoin security and
- * hashing model for blocks and transactions.
- *
- * @see {@link https://github.com/bcoin-org/bcrypto}
- *
- * @export
- * @class Hash
- */
 export class Hash {
-	/**
-	 * Hashes the given value using the RIPEMD160 algorithm.
-	 *
-	 * @static
-	 * @param {(Buffer | string)} buffer
-	 * @returns {Buffer}
-	 * @memberof Hash
-	 */
 	public static ripemd160(buffer: Buffer | string): Buffer {
-		return RIPEMD160.digest(Hash.#bufferize(buffer));
+		return Buffer.from(ripemd160(Hash.#bufferize(buffer)));
 	}
 
-	/**
-	 * Hashes the given value using the SHA1 algorithm.
-	 *
-	 * @static
-	 * @param {(Buffer | string)} buffer
-	 * @returns {Buffer}
-	 * @memberof Hash
-	 */
-	public static sha1(buffer: Buffer | string): Buffer {
-		return SHA1.digest(Hash.#bufferize(buffer));
+	public static sha256(buffer: Buffer | string): Buffer {
+		return Buffer.from(sha256(buffer));
 	}
 
-	/**
-	 * Hashes the given value using the SHA256 algorithm.
-	 *
-	 * @static
-	 * @param {(Buffer | string | Buffer[])} buffer
-	 * @returns {Buffer}
-	 * @memberof Hash
-	 */
-	public static sha256(buffer: Buffer | string | Buffer[]): Buffer {
-		if (Array.isArray(buffer)) {
-			let sha256 = SHA256.ctx;
-
-			sha256.init();
-
-			for (const element of buffer) {
-				sha256 = sha256.update(element);
-			}
-
-			return sha256.final();
-		}
-
-		return SHA256.digest(Hash.#bufferize(buffer));
-	}
-
-	/**
-	 * Hashes the given value using the HASH160 algorithm.
-	 *
-	 * @static
-	 * @param {(Buffer | string)} buffer
-	 * @returns {Buffer}
-	 * @memberof Hash
-	 */
-	public static hash160(buffer: Buffer | string): Buffer {
-		return Hash160.digest(Hash.#bufferize(buffer));
-	}
-
-	/**
-	 * Hashes the given value using the HASH256 algorithm.
-	 *
-	 * @static
-	 * @param {(Buffer | string)} buffer
-	 * @returns {Buffer}
-	 * @memberof Hash
-	 */
-	public static hash256(buffer: Buffer | string): Buffer {
-		return Hash256.digest(Hash.#bufferize(buffer));
-	}
-
-	/**
-	 * Ensures that we are always working with a Buffer before hashing.
-	 *
-	 * @private
-	 * @static
-	 * @param {(Buffer | string)} buffer
-	 * @returns
-	 * @memberof Hash
-	 */
 	static #bufferize(buffer: Buffer | string) {
 		return buffer instanceof Buffer ? buffer : Buffer.from(buffer);
 	}

--- a/packages/cryptography/source/hash.ts
+++ b/packages/cryptography/source/hash.ts
@@ -7,7 +7,7 @@ export class Hash {
 	}
 
 	public static sha256(buffer: Buffer | string): Buffer {
-		return Buffer.from(sha256(buffer));
+		return Buffer.from(sha256(Hash.#bufferize(buffer)));
 	}
 
 	static #bufferize(buffer: Buffer | string) {

--- a/packages/profiles/source/cache.service.ts
+++ b/packages/profiles/source/cache.service.ts
@@ -56,6 +56,6 @@ export class Cache implements ICache {
 	}
 
 	#getCacheKey(value: unknown): string {
-		return Hash.sha1(`${this.#prefix}.${JSON.stringify(value)}`).toString("hex");
+		return Hash.sha256(`${this.#prefix}.${JSON.stringify(value)}`).toString("hex");
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,7 @@ importers:
 
   packages/cryptography:
     specifiers:
+      '@noble/hashes': ^0.4.1
       '@payvo/sdk-test': workspace:*
       '@types/argon2-browser': 1.18.1
       '@types/bcryptjs': 2.4.2
@@ -283,6 +284,7 @@ importers:
       uuid: ^8.3.2
       wif: ^2.0.6
     dependencies:
+      '@noble/hashes': 0.4.1
       argon2-browser: 1.18.0
       bcryptjs: 2.4.3
       bcrypto: 5.4.0
@@ -1957,6 +1959,10 @@ packages:
 
   /@noble/ed25519/1.3.0:
     resolution: {integrity: sha512-k6ddjHcmfHF5LoZRv2j7WktgY8C8lzAqiu5ukWfGIlPUlpLn1tn1pfILXaXHY1DCG0s3qvGM1SluLtVpckWwMA==}
+    dev: false
+
+  /@noble/hashes/0.4.1:
+    resolution: {integrity: sha512-Qxy9mZoDf5SyFrQ8hpWHeMZ2Scmb9BAz/lt23sKdr/QHnACW9dD6S+/WVJHd3R/BPoNHcUYWXoXXe74cxSEYoA==}
     dev: false
 
   /@nodelib/fs.scandir/2.1.5:


### PR DESCRIPTION
Replaces `bcrypto` with `@noble/hashes` for hashing operations.