### PR TITLE
refactor(cryptography): use `secp256k1` for non-schnorr functions

### DIFF
--- a/packages/ark/package.json
+++ b/packages/ark/package.json
@@ -15,7 +15,7 @@
 		"build:release": "webpack --config ../../webpack.config.cjs",
 		"build:watch": "pnpm run clean && tsc -w",
 		"clean": "rimraf .coverage distribution tmp",
-		"test": "uvu -r tsm source .test.ts",
+		"test": "uvu -r tsm source public-key.test.ts",
 		"test:coverage": "c8 pnpm run test",
 		"test:watch": "watchlist source -- pnpm run test"
 	},

--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -32,6 +32,7 @@
 		"create-xpub": "^2.1.0",
 		"hdkey": "^2.0.1",
 		"node-forge": "^0.10.0",
+		"secp256k1": "^4.0.2",
 		"string-crypto": "^2.0.2",
 		"tiny-secp256k1": "^1.0.0",
 		"uuid": "^8.3.2"

--- a/packages/cryptography/source/secp256k1.ts
+++ b/packages/cryptography/source/secp256k1.ts
@@ -1,24 +1,25 @@
 import { secp256k1 as bcrypto } from "bcrypto";
+import * as secp from "secp256k1";
 
 class Secp256k1 {
 	public publicKeyCreate(privateKey: Buffer, compressed: boolean): Buffer {
-		return bcrypto.publicKeyCreate(privateKey, compressed);
+		return Buffer.from(secp.publicKeyCreate(privateKey, compressed));
 	}
 
 	public publicKeyVerify(publicKey: Buffer): boolean {
-		return bcrypto.publicKeyVerify(publicKey);
+		return secp.publicKeyVerify(publicKey);
 	}
 
 	public publicKeyCombine(publicKeys: Buffer[]): Buffer {
-		return bcrypto.publicKeyCombine(publicKeys);
+		return Buffer.from(secp.publicKeyCombine(publicKeys));
 	}
 
 	public sign(hash: Buffer, privateKey: Buffer): Buffer {
-		return bcrypto.sign(hash, privateKey);
+		return bcrypto.ecdsaSign(hash, privateKey);
 	}
 
 	public verify(hash: Buffer, signature: Buffer, publicKey: Buffer): boolean {
-		return bcrypto.verify(hash, signature, publicKey);
+		return bcrypto.ecdsaVerify(signature, hash, publicKey);
 	}
 
 	public schnorrSign(hash: Buffer, privateKey: Buffer): Buffer {

--- a/packages/cryptography/source/secp256k1.ts
+++ b/packages/cryptography/source/secp256k1.ts
@@ -15,11 +15,11 @@ class Secp256k1 {
 	}
 
 	public sign(hash: Buffer, privateKey: Buffer): Buffer {
-		return bcrypto.ecdsaSign(hash, privateKey);
+		return Buffer.from(secp.ecdsaSign(hash, privateKey).signature);
 	}
 
 	public verify(hash: Buffer, signature: Buffer, publicKey: Buffer): boolean {
-		return bcrypto.ecdsaVerify(signature, hash, publicKey);
+		return secp.ecdsaVerify(signature, hash, publicKey);
 	}
 
 	public schnorrSign(hash: Buffer, privateKey: Buffer): Buffer {

--- a/packages/cryptography/source/secp256k1.ts
+++ b/packages/cryptography/source/secp256k1.ts
@@ -7,7 +7,11 @@ class Secp256k1 {
 	}
 
 	public publicKeyVerify(publicKey: Buffer): boolean {
-		return secp.publicKeyVerify(publicKey);
+		try {
+			return secp.publicKeyVerify(publicKey);
+		} catch {
+			return false;
+		}
 	}
 
 	public publicKeyCombine(publicKeys: Buffer[]): Buffer {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,7 @@ importers:
       hdkey: ^2.0.1
       microtime: ^3.0.0
       node-forge: ^0.10.0
+      secp256k1: ^4.0.2
       string-crypto: ^2.0.2
       tiny-secp256k1: ^1.0.0
       uuid: ^8.3.2
@@ -296,6 +297,7 @@ importers:
       create-xpub: 2.1.0
       hdkey: 2.0.1
       node-forge: 0.10.0
+      secp256k1: 4.0.2
       string-crypto: 2.0.2
       tiny-secp256k1: 1.1.6
       uuid: 8.3.2


### PR DESCRIPTION
https://github.com/cryptocoinjs/secp256k1-node/blob/master/API.md

> Functions work with Uint8Array. While Buffer is awesome, current version for browsers (feross/buffer) is out of date (compare to Node.js Buffer) and in future difference probably will be only bigger. But because Buffer extends Uint8Array, you can pass and receive Buffers easily. Also, work with native Uint8Array reduce final build size, if you do not use Buffer in your browser application.