### PR TITLE
refactor: bundle `bcrypto` only with `ark`

### DIFF
--- a/packages/ark/package.json
+++ b/packages/ark/package.json
@@ -15,7 +15,7 @@
 		"build:release": "webpack --config ../../webpack.config.cjs",
 		"build:watch": "pnpm run clean && tsc -w",
 		"clean": "rimraf .coverage distribution tmp",
-		"test": "uvu -r tsm source public-key.test.ts",
+		"test": "uvu -r tsm source .test.ts",
 		"test:coverage": "c8 pnpm run test",
 		"test:watch": "watchlist source -- pnpm run test"
 	},

--- a/packages/ark/source/crypto/hash.ts
+++ b/packages/ark/source/crypto/hash.ts
@@ -1,4 +1,4 @@
-import { secp256k1 } from "@payvo/sdk-cryptography";
+import { secp256k1 } from "bcrypto";
 
 import { IKeyPair } from "./interfaces";
 

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -24,7 +24,6 @@
 		"@payvo/sdk-cryptography": "workspace:*",
 		"@payvo/sdk-helpers": "workspace:*",
 		"@payvo/sdk-intl": "workspace:*",
-		"bcrypto": "^5.4.0",
 		"ledger-cosmos-js": "^2.1.8"
 	},
 	"devDependencies": {

--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -23,7 +23,6 @@
 		"@noble/hashes": "^0.4.1",
 		"argon2-browser": "^1.18.0",
 		"bcryptjs": "^2.4.3",
-		"bcrypto": "^5.4.0",
 		"bech32": "^2.0.0",
 		"bip32": "^2.0.0",
 		"bip38": "^3.1.1",

--- a/packages/cryptography/source/secp256k1.ts
+++ b/packages/cryptography/source/secp256k1.ts
@@ -1,4 +1,3 @@
-import { secp256k1 as bcrypto } from "bcrypto";
 import * as secp from "secp256k1";
 
 class Secp256k1 {
@@ -24,14 +23,6 @@ class Secp256k1 {
 
 	public verify(hash: Buffer, signature: Buffer, publicKey: Buffer): boolean {
 		return secp.ecdsaVerify(signature, hash, publicKey);
-	}
-
-	public schnorrSign(hash: Buffer, privateKey: Buffer): Buffer {
-		return bcrypto.schnorrSign(hash, privateKey);
-	}
-
-	public schnorrVerify(hash: Buffer, signature: Buffer, publicKey: Buffer): boolean {
-		return bcrypto.schnorrVerify(hash, signature, publicKey);
 	}
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,7 +160,6 @@ importers:
       '@payvo/sdk-intl': workspace:*
       '@payvo/sdk-test': workspace:*
       '@types/node': ^16.11.10
-      bcrypto: ^5.4.0
       got: ^11.8.3
       ledger-cosmos-js: ^2.1.8
     dependencies:
@@ -168,7 +167,6 @@ importers:
       '@payvo/sdk-cryptography': link:../cryptography
       '@payvo/sdk-helpers': link:../helpers
       '@payvo/sdk-intl': link:../intl
-      bcrypto: 5.4.0
       ledger-cosmos-js: 2.1.8
     devDependencies:
       '@ledgerhq/hw-transport-mocker': 6.11.2
@@ -268,7 +266,6 @@ importers:
       '@types/wif': ^2.0.2
       argon2-browser: ^1.18.0
       bcryptjs: ^2.4.3
-      bcrypto: ^5.4.0
       bech32: ^2.0.0
       benchmark: ^2.1.4
       bip32: ^2.0.0
@@ -288,7 +285,6 @@ importers:
       '@noble/hashes': 0.4.1
       argon2-browser: 1.18.0
       bcryptjs: 2.4.3
-      bcrypto: 5.4.0
       bech32: 2.0.0
       bip32: 2.0.6
       bip38: 3.1.1


### PR DESCRIPTION
Bundle `bcrypto` only for `ark` because no one else needs it. ARK needs it for the broken legacy schnorr implementation that it exposes.