### PR TITLE
refactor(ark): adjust some `bcrypto` exports to match project style

### DIFF
--- a/packages/ark/package.json
+++ b/packages/ark/package.json
@@ -16,7 +16,7 @@
 		"build:release": "webpack --config ../../webpack.config.cjs",
 		"build:watch": "pnpm run clean && tsc -w",
 		"clean": "rimraf .coverage distribution tmp",
-		"test": "NODE_BACKEND=js uvu -r tsm source .test.ts",
+		"test": "uvu -r tsm source .test.ts",
 		"test:coverage": "c8 pnpm run test",
 		"test:watch": "watchlist source -- pnpm run test"
 	},

--- a/packages/ark/source/crypto/bcrypto/asn1.ts
+++ b/packages/ark/source/crypto/bcrypto/asn1.ts
@@ -264,4 +264,4 @@ export const asn1 = {
 	writeSeq,
 	writeInt,
 	writeVersion,
-}
+};

--- a/packages/ark/source/crypto/bcrypto/asn1.ts
+++ b/packages/ark/source/crypto/bcrypto/asn1.ts
@@ -8,8 +8,8 @@
 
 "use strict";
 
-import assert from "../internal/assert.js";
-import BN from "../bn";
+import { assert } from "./assert.js";
+import { BN } from "./bn.js";
 
 /*
  * ASN1
@@ -251,19 +251,17 @@ function writeVersion(data, pos, version) {
 	return pos;
 }
 
-/*
- * Expose
- */
-
-exports.readSize = readSize;
-exports.readSeq = readSeq;
-exports.readInt = readInt;
-exports.readVersion = readVersion;
-exports.sizeSize = sizeSize;
-exports.sizeSeq = sizeSeq;
-exports.sizeInt = sizeInt;
-exports.sizeVersion = sizeVersion;
-exports.writeSize = writeSize;
-exports.writeSeq = writeSeq;
-exports.writeInt = writeInt;
-exports.writeVersion = writeVersion;
+export const asn1 = {
+	readSize,
+	readSeq,
+	readInt,
+	readVersion,
+	sizeSize,
+	sizeSeq,
+	sizeInt,
+	sizeVersion,
+	writeSize,
+	writeSeq,
+	writeInt,
+	writeVersion,
+}

--- a/packages/ark/source/crypto/bcrypto/assert.ts
+++ b/packages/ark/source/crypto/bcrypto/assert.ts
@@ -12,7 +12,7 @@
  * Assert
  */
 
-function assert(val, msg) {
+export function assert(val, msg) {
 	if (!val) {
 		const err = new Error(msg || "Assertion failed");
 
@@ -21,9 +21,3 @@ function assert(val, msg) {
 		throw err;
 	}
 }
-
-/*
- * Expose
- */
-
-export default assert;

--- a/packages/ark/source/crypto/bcrypto/batch-rng.ts
+++ b/packages/ark/source/crypto/bcrypto/batch-rng.ts
@@ -17,16 +17,16 @@
 
 "use strict";
 
-import assert from "./internal/assert.js";
-import BN from "./bn.js";
-import ChaCha20 from "./chacha20.js";
-import SHA256 from "./sha256.js";
+import { assert } from "./assert.js";
+import { BN } from "./bn.js";
+import { ChaCha20 } from "./chacha20.js";
+import { SHA256 } from "./sha256.js";
 
 /**
  * BatchRNG
  */
 
-class BatchRNG {
+export class BatchRNG {
 	constructor(curve, encode = (key) => key) {
 		this.curve = curve;
 		this.encode = encode;
@@ -70,7 +70,7 @@ class BatchRNG {
 	refresh(counter) {
 		let overflow = 0;
 
-		for (;;) {
+		for (; ;) {
 			// First word is always zero.
 			this.iv[4] = overflow;
 			this.iv[5] = overflow >>> 8;

--- a/packages/ark/source/crypto/bcrypto/batch-rng.ts
+++ b/packages/ark/source/crypto/bcrypto/batch-rng.ts
@@ -70,7 +70,7 @@ export class BatchRNG {
 	refresh(counter) {
 		let overflow = 0;
 
-		for (; ;) {
+		for (;;) {
 			// First word is always zero.
 			this.iv[4] = overflow;
 			this.iv[5] = overflow >>> 8;

--- a/packages/ark/source/crypto/bcrypto/bn.ts
+++ b/packages/ark/source/crypto/bcrypto/bn.ts
@@ -1973,7 +1973,7 @@ class BN {
 			b.iushrn(shift);
 		}
 
-		for (; ;) {
+		for (;;) {
 			a._makeOdd();
 			b._makeOdd();
 
@@ -2241,7 +2241,7 @@ class BN {
 
 		let p = 3;
 
-		for (; ;) {
+		for (;;) {
 			if (p > 10000) {
 				// Thought to be impossible.
 				throw new Error(`Cannot find (D/n) = -1 for ${n.toString(10)}.`);
@@ -3594,7 +3594,7 @@ class BN {
 
 		if (bits === 0) return min.clone();
 
-		for (; ;) {
+		for (;;) {
 			const num = BN.randomBits(rng, bits);
 
 			// Maximum is _exclusive_!
@@ -3939,7 +3939,7 @@ class Prime116 extends Prime {
 		let b = this.powS(x);
 		let k = this.z;
 
-		for (; ;) {
+		for (;;) {
 			let t = b;
 			let m = 0;
 
@@ -4118,10 +4118,10 @@ class P521 extends Prime34 {
 		super(
 			"p521",
 			"000001ff ffffffff ffffffff ffffffff" +
-			"ffffffff ffffffff ffffffff ffffffff" +
-			"ffffffff ffffffff ffffffff ffffffff" +
-			"ffffffff ffffffff ffffffff ffffffff" +
-			"ffffffff",
+				"ffffffff ffffffff ffffffff ffffffff" +
+				"ffffffff ffffffff ffffffff ffffffff" +
+				"ffffffff ffffffff ffffffff ffffffff" +
+				"ffffffff",
 		);
 	}
 
@@ -4509,9 +4509,9 @@ class P448 extends Prime34 {
 		super(
 			"p448",
 			"ffffffff ffffffff ffffffff ffffffff" +
-			"ffffffff ffffffff fffffffe ffffffff" +
-			"ffffffff ffffffff ffffffff ffffffff" +
-			"ffffffff ffffffff",
+				"ffffffff ffffffff fffffffe ffffffff" +
+				"ffffffff ffffffff ffffffff ffffffff" +
+				"ffffffff ffffffff",
 		);
 	}
 
@@ -5013,7 +5013,7 @@ class Red {
 		let y = this.pow(x, s.iaddn(1).iushrn(1));
 		let k = e;
 
-		for (; ;) {
+		for (;;) {
 			let t = b;
 			let m = 0;
 

--- a/packages/ark/source/crypto/bcrypto/bn.ts
+++ b/packages/ark/source/crypto/bcrypto/bn.ts
@@ -42,7 +42,7 @@
 
 "use strict";
 
-import { custom } from "./internal/custom.js";
+import { custom } from "./custom.js";
 
 /*
  * Constants
@@ -1973,7 +1973,7 @@ class BN {
 			b.iushrn(shift);
 		}
 
-		for (;;) {
+		for (; ;) {
 			a._makeOdd();
 			b._makeOdd();
 
@@ -2241,7 +2241,7 @@ class BN {
 
 		let p = 3;
 
-		for (;;) {
+		for (; ;) {
 			if (p > 10000) {
 				// Thought to be impossible.
 				throw new Error(`Cannot find (D/n) = -1 for ${n.toString(10)}.`);
@@ -3594,7 +3594,7 @@ class BN {
 
 		if (bits === 0) return min.clone();
 
-		for (;;) {
+		for (; ;) {
 			const num = BN.randomBits(rng, bits);
 
 			// Maximum is _exclusive_!
@@ -3939,7 +3939,7 @@ class Prime116 extends Prime {
 		let b = this.powS(x);
 		let k = this.z;
 
-		for (;;) {
+		for (; ;) {
 			let t = b;
 			let m = 0;
 
@@ -4118,10 +4118,10 @@ class P521 extends Prime34 {
 		super(
 			"p521",
 			"000001ff ffffffff ffffffff ffffffff" +
-				"ffffffff ffffffff ffffffff ffffffff" +
-				"ffffffff ffffffff ffffffff ffffffff" +
-				"ffffffff ffffffff ffffffff ffffffff" +
-				"ffffffff",
+			"ffffffff ffffffff ffffffff ffffffff" +
+			"ffffffff ffffffff ffffffff ffffffff" +
+			"ffffffff ffffffff ffffffff ffffffff" +
+			"ffffffff",
 		);
 	}
 
@@ -4509,9 +4509,9 @@ class P448 extends Prime34 {
 		super(
 			"p448",
 			"ffffffff ffffffff ffffffff ffffffff" +
-				"ffffffff ffffffff fffffffe ffffffff" +
-				"ffffffff ffffffff ffffffff ffffffff" +
-				"ffffffff ffffffff",
+			"ffffffff ffffffff fffffffe ffffffff" +
+			"ffffffff ffffffff ffffffff ffffffff" +
+			"ffffffff ffffffff",
 		);
 	}
 
@@ -5013,7 +5013,7 @@ class Red {
 		let y = this.pow(x, s.iaddn(1).iushrn(1));
 		let k = e;
 
-		for (;;) {
+		for (; ;) {
 			let t = b;
 			let m = 0;
 
@@ -6553,4 +6553,4 @@ if (!Math.imul) comb10MulTo = smallMulTo;
 
 BN.Red = Red;
 
-export default BN;
+export { BN };

--- a/packages/ark/source/crypto/bcrypto/chacha20.ts
+++ b/packages/ark/source/crypto/bcrypto/chacha20.ts
@@ -13,7 +13,7 @@
 
 "use strict";
 
-import assert from "./internal/assert.js";
+import { assert } from "./assert.js";
 
 /*
  * Constants
@@ -275,4 +275,4 @@ function writeU32(dst, num, off) {
  * Expose
  */
 
-export default ChaCha20;
+export { ChaCha20 };

--- a/packages/ark/source/crypto/bcrypto/custom.ts
+++ b/packages/ark/source/crypto/bcrypto/custom.ts
@@ -10,4 +10,4 @@
 
 import { inspect } from "util";
 
-exports.custom = inspect.custom || "inspect";
+export const custom = inspect.custom || "inspect";

--- a/packages/ark/source/crypto/bcrypto/ecdsa.ts
+++ b/packages/ark/source/crypto/bcrypto/ecdsa.ts
@@ -31,19 +31,19 @@
 
 "use strict";
 
-import assert from "./internal/assert.js";
-import BN from "./bn.js";
-import rng from "./random.js";
-import asn1 from "./internal/asn1.js";
-import Schnorr from "./schnorr-legacy.js";
-import HmacDRBG from "./hmac-drbg.js";
-import elliptic from "./elliptic.js";
+import { assert } from "./assert.js";
+import { BN } from "./bn.js";
+import { rng } from "./random.js";
+import { asn1 } from "./asn1.js";
+import { Schnorr } from "./schnorr-legacy.js";
+import { HmacDRBG } from "./hmac-drbg.js";
+import { elliptic } from "./elliptic.js";
 
 /**
  * ECDSA
  */
 
-class ECDSA {
+export class ECDSA {
 	constructor(name, hash, xof, pre) {
 		assert(typeof name === "string");
 		assert(hash);
@@ -433,7 +433,7 @@ class ECDSA {
 		const nonce = this.curve.encodeScalar(m);
 		const drbg = new HmacDRBG(this.hash, key, nonce);
 
-		for (;;) {
+		for (; ;) {
 			const bytes = drbg.generate(this.curve.scalarSize);
 			const k = this._truncate(bytes);
 
@@ -789,9 +789,3 @@ class ECDSA {
 		return this._truncate(msg).imod(this.curve.n);
 	}
 }
-
-/*
- * Expose
- */
-
-export default ECDSA;

--- a/packages/ark/source/crypto/bcrypto/ecdsa.ts
+++ b/packages/ark/source/crypto/bcrypto/ecdsa.ts
@@ -433,7 +433,7 @@ export class ECDSA {
 		const nonce = this.curve.encodeScalar(m);
 		const drbg = new HmacDRBG(this.hash, key, nonce);
 
-		for (; ;) {
+		for (;;) {
 			const bytes = drbg.generate(this.curve.scalarSize);
 			const k = this._truncate(bytes);
 

--- a/packages/ark/source/crypto/bcrypto/elliptic.ts
+++ b/packages/ark/source/crypto/bcrypto/elliptic.ts
@@ -159,8 +159,8 @@
 
 "use strict";
 
-import { custom } from "./internal/custom.js";
-import BN from "./bn.js";
+import { custom } from "./custom.js";
+import { BN } from "./bn.js";
 
 /*
  * Constants
@@ -790,7 +790,7 @@ class Curve {
 		//   Elligator 1 (~2 iterations) => 6I + 10R
 		//   Elligator 2 (~2 iterations) => 4I + 6R
 		//   Ristretto (~1 iteration) => 1I + 2R + h*1R
-		for (;;) {
+		for (; ;) {
 			const u1 = this.randomField(rng);
 			const p1 = this.pointFromUniform(u1);
 
@@ -830,7 +830,7 @@ class Curve {
 	randomPoint(rng) {
 		let p;
 
-		for (;;) {
+		for (; ;) {
 			const x = this.randomField(rng);
 			const sign = (randomInt(rng) & 1) !== 0;
 
@@ -1911,7 +1911,7 @@ class ShortCurve extends Curve {
 
 		let p;
 
-		for (;;) {
+		for (; ;) {
 			x.redIAdd(this.one);
 
 			try {
@@ -5581,7 +5581,7 @@ class XPoint extends Point {
 			const bit = k.bit(i);
 
 			if (bit === 0) [a, b] = this.diffAddDbl(a, b);
-			else [b, a] = this.diffAddDbl(b, a);
+			else[b, a] = this.diffAddDbl(b, a);
 		}
 
 		return a;
@@ -8786,16 +8786,18 @@ function toPretty(x, size) {
  * Expose
  */
 
-exports.Curve = Curve;
-exports.Point = Point;
-exports.ShortCurve = ShortCurve;
-exports.ShortPoint = ShortPoint;
-exports.JPoint = JPoint;
-exports.MontCurve = MontCurve;
-exports.MontPoint = MontPoint;
-exports.XPoint = XPoint;
-exports.EdwardsCurve = EdwardsCurve;
-exports.EdwardsPoint = EdwardsPoint;
-exports.curves = curves;
-exports.curve = curve;
-exports.register = register;
+export const elliptic = {
+	Curve,
+	Point,
+	ShortCurve,
+	ShortPoint,
+	JPoint,
+	MontCurve,
+	MontPoint,
+	XPoint,
+	EdwardsCurve,
+	EdwardsPoint,
+	curves,
+	curve,
+	register,
+};

--- a/packages/ark/source/crypto/bcrypto/elliptic.ts
+++ b/packages/ark/source/crypto/bcrypto/elliptic.ts
@@ -790,7 +790,7 @@ class Curve {
 		//   Elligator 1 (~2 iterations) => 6I + 10R
 		//   Elligator 2 (~2 iterations) => 4I + 6R
 		//   Ristretto (~1 iteration) => 1I + 2R + h*1R
-		for (; ;) {
+		for (;;) {
 			const u1 = this.randomField(rng);
 			const p1 = this.pointFromUniform(u1);
 
@@ -830,7 +830,7 @@ class Curve {
 	randomPoint(rng) {
 		let p;
 
-		for (; ;) {
+		for (;;) {
 			const x = this.randomField(rng);
 			const sign = (randomInt(rng) & 1) !== 0;
 
@@ -1911,7 +1911,7 @@ class ShortCurve extends Curve {
 
 		let p;
 
-		for (; ;) {
+		for (;;) {
 			x.redIAdd(this.one);
 
 			try {
@@ -5581,7 +5581,7 @@ class XPoint extends Point {
 			const bit = k.bit(i);
 
 			if (bit === 0) [a, b] = this.diffAddDbl(a, b);
-			else[b, a] = this.diffAddDbl(b, a);
+			else [b, a] = this.diffAddDbl(b, a);
 		}
 
 		return a;

--- a/packages/ark/source/crypto/bcrypto/hmac-drbg.ts
+++ b/packages/ark/source/crypto/bcrypto/hmac-drbg.ts
@@ -17,7 +17,7 @@
 
 "use strict";
 
-import assert from "./internal/assert.js";
+import { assert } from "./assert.js";
 
 /*
  * Constants
@@ -165,4 +165,4 @@ HmacDRBG.native = 0;
  * Expose
  */
 
-export default HmacDRBG;
+export { HmacDRBG };

--- a/packages/ark/source/crypto/bcrypto/hmac.ts
+++ b/packages/ark/source/crypto/bcrypto/hmac.ts
@@ -17,7 +17,7 @@
 
 "use strict";
 
-import assert from "../internal/assert.js";
+import { assert } from "./assert.js";
 
 /**
  * HMAC
@@ -113,4 +113,4 @@ class HMAC {
  * Expose
  */
 
-export default HMAC;
+export { HMAC };

--- a/packages/ark/source/crypto/bcrypto/random.ts
+++ b/packages/ark/source/crypto/bcrypto/random.ts
@@ -14,7 +14,7 @@
 
 "use strict";
 
-import assert from "./internal/assert.js";
+import { assert } from "./assert.js";
 import getRandomValues from "get-random-values";
 
 /*
@@ -144,8 +144,10 @@ function randomFillSync(data, off, size) {
  * Expose
  */
 
-exports.native = 0;
-exports.randomBytes = randomBytes;
-exports.randomFill = randomFill;
-exports.randomInt = randomInt;
-exports.randomRange = randomRange;
+export const rng = {
+	native: 0,
+	randomBytes,
+	randomFill,
+	randomInt,
+	randomRange,
+};

--- a/packages/ark/source/crypto/bcrypto/schnorr-legacy.ts
+++ b/packages/ark/source/crypto/bcrypto/schnorr-legacy.ts
@@ -33,15 +33,15 @@
 
 "use strict";
 
-import assert from "./internal/assert.js";
-import BatchRNG from "./batch-rng.js";
-import BN from "./bn.js";
+import { assert } from "./assert.js";
+import { BatchRNG } from "./batch-rng.js";
+import { BN } from "./bn.js";
 
 /**
  * Schnorr
  */
 
-class Schnorr {
+export class Schnorr {
 	constructor(curve, hash) {
 		this.curve = curve;
 		this.hash = hash;
@@ -320,9 +320,3 @@ class Schnorr {
 		return this.curve.jmulAll(points, coeffs).isInfinity();
 	}
 }
-
-/*
- * Expose
- */
-
-export default Schnorr;

--- a/packages/ark/source/crypto/bcrypto/secp256k1.ts
+++ b/packages/ark/source/crypto/bcrypto/secp256k1.ts
@@ -9,14 +9,10 @@
 
 "use strict";
 
-import ECDSA from "./ecdsa.js";
-import SHA256 from "./sha256.js";
+import { ECDSA } from "./ecdsa.js";
+import { SHA256 } from "./sha256.js";
 
-/*
- * Expose
- */
-
-export default new ECDSA("SECP256K1", SHA256, SHA256, {
+export const secp256k1 = new ECDSA("SECP256K1", SHA256, SHA256, {
 	naf: {
 		width: 9,
 		points: [

--- a/packages/ark/source/crypto/bcrypto/sha256.ts
+++ b/packages/ark/source/crypto/bcrypto/sha256.ts
@@ -17,8 +17,8 @@
 
 "use strict";
 
-import assert from "./internal/assert.js";
-import HMAC from "./internal/hmac.js";
+import { assert } from "./assert.js";
+import { HMAC } from "./hmac.js";
 
 /*
  * Constants
@@ -270,4 +270,4 @@ function writeU32(data, num, off) {
  * Expose
  */
 
-export default SHA256;
+export { SHA256 };

--- a/packages/ark/source/crypto/hash.ts
+++ b/packages/ark/source/crypto/hash.ts
@@ -1,4 +1,4 @@
-import secp256k1 from "./bcrypto/secp256k1.js";
+import { secp256k1 } from "./bcrypto/secp256k1.js";
 import { IKeyPair } from "./interfaces";
 
 export class Hash {


### PR DESCRIPTION
Title and also removes `NODE_BACKEND=js` because we now only include the pure JavaScript implementations.