### PR TITLE
feat(trx): improve address validation implementation

### DIFF
--- a/packages/trx/package.json
+++ b/packages/trx/package.json
@@ -26,7 +26,6 @@
 		"@payvo/sdk-cryptography": "workspace:*",
 		"@payvo/sdk-helpers": "workspace:*",
 		"@payvo/sdk-intl": "workspace:*",
-		"multicoin-address-validator": "^0.5.5",
 		"tronweb": "^4.0.1"
 	},
 	"devDependencies": {

--- a/packages/trx/source/address.service.test.ts
+++ b/packages/trx/source/address.service.test.ts
@@ -5,7 +5,7 @@ import { AddressService } from "./address.service";
 
 describe("AddressService", async ({ beforeEach, it, assert }) => {
 	beforeEach(async (context) => {
-		context.subject = await createService(AddressService);
+		context.subject = await createService(AddressService, "trx.mainnet");
 	});
 
 	it("should generate an output from a mnemonic", async (context) => {

--- a/packages/trx/source/address.service.ts
+++ b/packages/trx/source/address.service.ts
@@ -1,6 +1,5 @@
-import { Coins, IoC, Services } from "@payvo/sdk";
-import { BIP44 } from "@payvo/sdk-cryptography";
-import { validate } from "multicoin-address-validator";
+import { Coins, Services } from "@payvo/sdk";
+import { Base58, BIP44, Hash } from "@payvo/sdk-cryptography";
 import TronWeb from "tronweb";
 
 export class AddressService extends Services.AbstractAddressService {
@@ -21,6 +20,33 @@ export class AddressService extends Services.AbstractAddressService {
 	}
 
 	public override async validate(address: string): Promise<boolean> {
-		return validate(address, "TRX");
+		try {
+			const result: Buffer = this.#decodeBase58Address(address);
+
+			if (result && result.length !== 21) {
+				return false;
+			}
+
+			if (this.configRepository.get("network.id") === "trx.mainnet") {
+				return result[0] === 0x41;
+			}
+
+			return result[0] === 0xa0;
+		} catch {
+			return false;
+		}
+	}
+
+	#decodeBase58Address(base58Sting): Buffer {
+		const address: Buffer = Base58.decode(base58Sting);
+		const offset: number = address.length - 4;
+		const expected: Buffer = address.slice(offset);
+		const actual: Buffer = Hash.sha256(Hash.sha256(Buffer.from(address.slice(0, offset)))).slice(0, 4);
+
+        if (expected[0] === actual[0] && expected[1] === actual[1] && expected[2] === actual[2] && expected[3] === actual[3]) {
+			return address.slice(0, offset);
+		}
+
+		throw new Error("Failed to decode base58 string.");
 	}
 }

--- a/packages/trx/source/address.service.ts
+++ b/packages/trx/source/address.service.ts
@@ -43,7 +43,12 @@ export class AddressService extends Services.AbstractAddressService {
 		const expected: Buffer = address.slice(offset);
 		const actual: Buffer = Hash.sha256(Hash.sha256(Buffer.from(address.slice(0, offset)))).slice(0, 4);
 
-        if (expected[0] === actual[0] && expected[1] === actual[1] && expected[2] === actual[2] && expected[3] === actual[3]) {
+		if (
+			expected[0] === actual[0] &&
+			expected[1] === actual[1] &&
+			expected[2] === actual[2] &&
+			expected[3] === actual[3]
+		) {
 			return address.slice(0, offset);
 		}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -758,7 +758,6 @@ importers:
       '@payvo/sdk-intl': workspace:*
       '@payvo/sdk-test': workspace:*
       '@types/node': ^16.11.10
-      multicoin-address-validator: ^0.5.5
       tronweb: ^4.0.1
     dependencies:
       '@ledgerhq/hw-app-trx': 6.11.2
@@ -766,7 +765,6 @@ importers:
       '@payvo/sdk-cryptography': link:../cryptography
       '@payvo/sdk-helpers': link:../helpers
       '@payvo/sdk-intl': link:../intl
-      multicoin-address-validator: 0.5.5
       tronweb: 4.0.1
     devDependencies:
       '@ledgerhq/hw-transport-mocker': 6.11.2
@@ -3914,10 +3912,6 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /browserify-bignum/1.3.0-2:
-    resolution: {integrity: sha1-3cO27WB/1slglmlQ4rNaKwxvub8=}
-    dev: false
-
   /browserify-cipher/1.0.1:
     resolution: {integrity: sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==}
     dependencies:
@@ -4075,10 +4069,6 @@ packages:
     resolution: {integrity: sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=}
     dev: false
 
-  /bundle/2.1.0:
-    resolution: {integrity: sha512-d7TeT8m2HuymDjSEmMppWe/h5SSPPUZkaWKrAofx6gNXDdZ3FL/81oOTGPG+LIaZbNr9m4rtUi98Yw0Q1vHIIw==}
-    dev: false
-
   /bytebuffer/5.0.1:
     resolution: {integrity: sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=}
     engines: {node: '>=0.8'}
@@ -4160,13 +4150,6 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /camel-case/4.1.2:
-    resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
-    dependencies:
-      pascal-case: 3.1.2
-      tslib: 2.3.1
-    dev: false
-
   /camelcase/5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -4178,10 +4161,6 @@ packages:
 
   /caseless/0.12.0:
     resolution: {integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=}
-    dev: false
-
-  /cbor-js/0.1.0:
-    resolution: {integrity: sha1-yAzmEg84fo+qdDcN/aIdlluPx/k=}
     dev: false
 
   /censorify-it/3.0.2:
@@ -4270,13 +4249,6 @@ packages:
 
   /class-is/1.1.0:
     resolution: {integrity: sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==}
-    dev: false
-
-  /clean-css/5.2.2:
-    resolution: {integrity: sha512-/eR8ru5zyxKzpBLv9YZvMXgTSSQn7AdkMItMYynsFgGwTveCRVam9IUPFloE85B4vAIj05IuKmmEoV7/AQjT0w==}
-    engines: {node: '>= 10.0'}
-    dependencies:
-      source-map: 0.6.1
     dev: false
 
   /clean-regexp/1.0.0:
@@ -4384,11 +4356,6 @@ packages:
   /commander/7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
-    dev: false
-
-  /commander/8.3.0:
-    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
-    engines: {node: '>= 12'}
     dev: false
 
   /concat-map/0.0.1:
@@ -4591,11 +4558,6 @@ packages:
 
   /crypto-js/4.0.0:
     resolution: {integrity: sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==}
-    dev: false
-
-  /css-b64-images/0.2.5:
-    resolution: {integrity: sha1-QgBdgyBLK0pdk7axpWRBM7WSegI=}
-    hasBin: true
     dev: false
 
   /cssom/0.3.8:
@@ -4895,13 +4857,6 @@ packages:
 
   /dompurify/2.3.3:
     resolution: {integrity: sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==}
-    dev: false
-
-  /dot-case/3.0.4:
-    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.3.1
     dev: false
 
   /dot-prop/6.0.1:
@@ -6034,14 +5989,6 @@ packages:
       path-exists: 4.0.0
     dev: false
 
-  /find-up/6.2.0:
-    resolution: {integrity: sha512-yWHzMzXCaFoABSnFTCPKNFlYoq4mSga9QLRRKOCLSJ33hSkzROB14ITbAWW0QDQDyuzsPQ33S1DsOWQb/oW1yA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      locate-path: 7.0.0
-      path-exists: 5.0.0
-    dev: false
-
   /flat-cache/3.0.4:
     resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -6559,11 +6506,6 @@ packages:
       secp256k1: 4.0.2
     dev: false
 
-  /he/1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
-    dev: false
-
   /hmac-drbg/1.0.1:
     resolution: {integrity: sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=}
     dependencies:
@@ -6592,22 +6534,6 @@ packages:
 
   /html-escaper/2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
-    dev: false
-
-  /html-minifier-terser/6.1.0:
-    resolution: {integrity: sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==}
-    engines: {node: '>=12'}
-    hasBin: true
-    dependencies:
-      camel-case: 4.1.2
-      clean-css: 5.2.2
-      commander: 8.3.0
-      he: 1.2.0
-      param-case: 3.0.4
-      relateurl: 0.2.7
-      terser: 5.10.0
-    transitivePeerDependencies:
-      - acorn
     dev: false
 
   /http-cache-semantics/4.1.0:
@@ -7189,10 +7115,6 @@ packages:
       supports-color: 8.1.1
     dev: false
 
-  /jju/1.4.0:
-    resolution: {integrity: sha1-o6vicYryQaKykE+EpiWXDzia4yo=}
-    dev: false
-
   /joi/17.4.2:
     resolution: {integrity: sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==}
     dependencies:
@@ -7209,10 +7131,6 @@ packages:
 
   /js-sha3/0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
-    dev: false
-
-  /js-sha512/0.8.0:
-    resolution: {integrity: sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==}
     dev: false
 
   /js-string-escape/1.0.1:
@@ -7578,23 +7496,12 @@ packages:
       p-locate: 5.0.0
     dev: false
 
-  /locate-path/7.0.0:
-    resolution: {integrity: sha512-+cg2yXqDUKfo4hsFxwa3G1cBJeA+gs1vD8FyV9/odWoUlQe/4syxHQ5DPtKjtfm6gnKbZzjCqzX03kXosvZB1w==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      p-locate: 6.0.0
-    dev: false
-
   /lodash.clonedeep/4.5.0:
     resolution: {integrity: sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=}
     dev: false
 
   /lodash.get/4.4.2:
     resolution: {integrity: sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=}
-    dev: false
-
-  /lodash.isequal/4.5.0:
-    resolution: {integrity: sha1-QVxEePK8wwEgwizhDtMib30+GOA=}
     dev: false
 
   /lodash.merge/4.6.2:
@@ -7641,12 +7548,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: false
-
-  /lower-case/2.0.2:
-    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
-    dependencies:
-      tslib: 2.3.1
     dev: false
 
   /lowercase-keys/1.0.1:
@@ -7798,26 +7699,6 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /minify/8.0.3:
-    resolution: {integrity: sha512-ULGYQLO0YmRzVsJEN5sMd6/VFTOWXFjk64DEPMgoItjFBglgosL1fT/9OrSNMQDB2Zz/fHOeip/eH84gK4Xr+w==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dependencies:
-      clean-css: 5.2.2
-      css-b64-images: 0.2.5
-      debug: 4.3.2
-      find-up: 6.2.0
-      html-minifier-terser: 6.1.0
-      readjson: 2.2.2
-      simport: 1.2.0
-      terser: 5.10.0
-      try-catch: 3.0.0
-      try-to-catch: 3.0.0
-    transitivePeerDependencies:
-      - acorn
-      - supports-color
-    dev: false
-
   /minimalistic-assert/1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
     dev: false
@@ -7939,23 +7820,6 @@ packages:
       varint: 5.0.2
     dev: false
 
-  /multicoin-address-validator/0.5.5:
-    resolution: {integrity: sha512-X61bplNpovk1tOmrqBdueUh/YR1J2wsxG8ouqkA/g9ySppYBkNTmgyBbIrnSu8sIo4hhXfUKF9u2g0nwPv+npg==}
-    dependencies:
-      base-x: 3.0.9
-      browserify-bignum: 1.3.0-2
-      bundle: 2.1.0
-      cbor-js: 0.1.0
-      crc: 3.8.0
-      js-sha512: 0.8.0
-      jssha: 2.4.2
-      lodash.isequal: 4.5.0
-      minify: 8.0.3
-    transitivePeerDependencies:
-      - acorn
-      - supports-color
-    dev: false
-
   /multihashes/0.4.21:
     resolution: {integrity: sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==}
     dependencies:
@@ -8028,13 +7892,6 @@ packages:
       '@sinonjs/text-encoding': 0.7.1
       just-extend: 4.2.1
       path-to-regexp: 1.8.0
-    dev: false
-
-  /no-case/3.0.4:
-    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
-    dependencies:
-      lower-case: 2.0.2
-      tslib: 2.3.1
     dev: false
 
   /nock/13.2.1:
@@ -8396,13 +8253,6 @@ packages:
       yocto-queue: 0.1.0
     dev: false
 
-  /p-limit/4.0.0:
-    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      yocto-queue: 1.0.0
-    dev: false
-
   /p-locate/2.0.0:
     resolution: {integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=}
     engines: {node: '>=4'}
@@ -8422,13 +8272,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
-    dev: false
-
-  /p-locate/6.0.0:
-    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      p-limit: 4.0.0
     dev: false
 
   /p-queue/7.1.0:
@@ -8484,13 +8327,6 @@ packages:
     resolution: {integrity: sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==}
     dev: false
 
-  /param-case/3.0.4:
-    resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.3.1
-    dev: false
-
   /parent-module/1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -8531,13 +8367,6 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /pascal-case/3.1.2:
-    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.3.1
-    dev: false
-
   /path-browserify/1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
     dev: false
@@ -8550,11 +8379,6 @@ packages:
   /path-exists/4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-    dev: false
-
-  /path-exists/5.0.0:
-    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: false
 
   /path-is-absolute/1.0.1:
@@ -8994,14 +8818,6 @@ packages:
       picomatch: 2.3.0
     dev: false
 
-  /readjson/2.2.2:
-    resolution: {integrity: sha512-PdeC9tsmLWBiL8vMhJvocq+OezQ3HhsH2HrN7YkhfYcTjQSa/iraB15A7Qvt7Xpr0Yd2rDNt6GbFwVQDg3HcAw==}
-    engines: {node: '>=10'}
-    dependencies:
-      jju: 1.4.0
-      try-catch: 3.0.0
-    dev: false
-
   /rechoir/0.6.2:
     resolution: {integrity: sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=}
     engines: {node: '>= 0.10'}
@@ -9028,11 +8844,6 @@ packages:
   /regexpp/3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
-    dev: false
-
-  /relateurl/0.2.7:
-    resolution: {integrity: sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=}
-    engines: {node: '>= 0.10'}
     dev: false
 
   /request/2.88.2:
@@ -9511,14 +9322,6 @@ packages:
       simple-concat: 1.0.1
     dev: false
 
-  /simport/1.2.0:
-    resolution: {integrity: sha512-85Bm7pKsqiiQ8rmYCaPDdlXZjJvuW6/k/FY8MTtLFMgU7f8S00CgTHfRtWB6KwSb6ek4p9YyG2enG1+yJbl+CA==}
-    engines: {node: '>=12.2'}
-    dependencies:
-      readjson: 2.2.2
-      try-to-catch: 3.0.0
-    dev: false
-
   /sinon/12.0.1:
     resolution: {integrity: sha512-iGu29Xhym33ydkAT+aNQFBINakjq69kKO6ByPvTsm3yyIACfyQttRTP03aBP/I8GfhFmLzrnKwNNkr0ORb1udg==}
     dependencies:
@@ -9976,21 +9779,6 @@ packages:
       - acorn
     dev: false
 
-  /terser/5.10.0:
-    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    peerDependencies:
-      acorn: ^8.5.0
-    peerDependenciesMeta:
-      acorn:
-        optional: true
-    dependencies:
-      commander: 2.20.3
-      source-map: 0.7.3
-      source-map-support: 0.5.21
-    dev: false
-
   /terser/5.10.0_acorn@8.6.0:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
     engines: {node: '>=10'}
@@ -10161,16 +9949,6 @@ packages:
       - bufferutil
       - debug
       - utf-8-validate
-    dev: false
-
-  /try-catch/3.0.0:
-    resolution: {integrity: sha512-3uAqUnoemzca1ENvZ72EVimR+E8lqBbzwZ9v4CEbLjkaV3Q+FtdmPUt7jRtoSoTiYjyIMxEkf6YgUpe/voJ1ng==}
-    engines: {node: '>=6'}
-    dev: false
-
-  /try-to-catch/3.0.0:
-    resolution: {integrity: sha512-eIm6ZXwR35jVF8By/HdbbkcaCDTBI5PpCPkejRKrYp0jyf/DbCCcRhHD7/O9jtFI3ewsqo9WctFEiJTS6i+CQA==}
-    engines: {node: '>=6'}
     dev: false
 
   /ts-loader/9.2.6_typescript@4.5.2+webpack@5.64.4:
@@ -11425,11 +11203,6 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-    dev: false
-
-  /yocto-queue/1.0.0:
-    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
-    engines: {node: '>=12.20'}
     dev: false
 
   /zod/3.11.6:


### PR DESCRIPTION
> Resolves https://github.com/PayvoHQ/sdk/issues/478

Replaces `multicoin-address-validator` with a much smaller implementation that reuses our existing hashing and base58 implementations.