### PR TITLE
refactor(trx): use `Buffer.compare` for address checksum comparison

### DIFF
--- a/packages/trx/source/address.service.ts
+++ b/packages/trx/source/address.service.ts
@@ -21,7 +21,16 @@ export class AddressService extends Services.AbstractAddressService {
 
 	public override async validate(address: string): Promise<boolean> {
 		try {
-			const result: Buffer = this.#decodeBase58Address(address);
+            const decoded: Buffer = Base58.decode(address);
+            const offset: number = decoded.length - 4;
+            const expected: Buffer = decoded.slice(offset);
+            const actual: Buffer = Hash.sha256(Hash.sha256(Buffer.from(decoded.slice(0, offset)))).slice(0, 4);
+
+            if (actual.compare(expected) !== 0) {
+                return false;
+            }
+
+            const result: Buffer = decoded.slice(0, offset);
 
 			if (result && result.length !== 21) {
 				return false;
@@ -35,23 +44,5 @@ export class AddressService extends Services.AbstractAddressService {
 		} catch {
 			return false;
 		}
-	}
-
-	#decodeBase58Address(base58Sting): Buffer {
-		const address: Buffer = Base58.decode(base58Sting);
-		const offset: number = address.length - 4;
-		const expected: Buffer = address.slice(offset);
-		const actual: Buffer = Hash.sha256(Hash.sha256(Buffer.from(address.slice(0, offset)))).slice(0, 4);
-
-		if (
-			expected[0] === actual[0] &&
-			expected[1] === actual[1] &&
-			expected[2] === actual[2] &&
-			expected[3] === actual[3]
-		) {
-			return address.slice(0, offset);
-		}
-
-		throw new Error("Failed to decode base58 string.");
 	}
 }

--- a/packages/trx/source/address.service.ts
+++ b/packages/trx/source/address.service.ts
@@ -21,16 +21,16 @@ export class AddressService extends Services.AbstractAddressService {
 
 	public override async validate(address: string): Promise<boolean> {
 		try {
-            const decoded: Buffer = Base58.decode(address);
-            const offset: number = decoded.length - 4;
-            const expected: Buffer = decoded.slice(offset);
-            const actual: Buffer = Hash.sha256(Hash.sha256(Buffer.from(decoded.slice(0, offset)))).slice(0, 4);
+			const decoded: Buffer = Base58.decode(address);
+			const offset: number = decoded.length - 4;
+			const expected: Buffer = decoded.slice(offset);
+			const actual: Buffer = Hash.sha256(Hash.sha256(Buffer.from(decoded.slice(0, offset)))).slice(0, 4);
 
-            if (actual.compare(expected) !== 0) {
-                return false;
-            }
+			if (actual.compare(expected) !== 0) {
+				return false;
+			}
 
-            const result: Buffer = decoded.slice(0, offset);
+			const result: Buffer = decoded.slice(0, offset);
 
 			if (result && result.length !== 21) {
 				return false;


### PR DESCRIPTION
Bit of cleanup for Tron address validation for consistency with other packages.