### PR TITLE
refactor(cryptography): use `micro-base` for `base58` and `bech32` operations

### DIFF
--- a/packages/ark/source/crypto/transactions/types/ipfs.ts
+++ b/packages/ark/source/crypto/transactions/types/ipfs.ts
@@ -27,7 +27,7 @@ export abstract class IpfsTransaction extends Transaction {
 		const { data } = this;
 
 		if (data.asset) {
-			const ipfsBuffer: Buffer = Base58.decode(data.asset.ipfs!);
+			const ipfsBuffer: Buffer = Buffer.from(Base58.decode(data.asset.ipfs!));
 			const buffer: ByteBuffer = new ByteBuffer(ipfsBuffer.length, true);
 
 			buffer.append(ipfsBuffer, "hex");

--- a/packages/atom/source/address.service.ts
+++ b/packages/atom/source/address.service.ts
@@ -12,7 +12,10 @@ export class AddressService extends Services.AbstractAddressService {
 		});
 
 		return {
-			address: bech32.encode(this.configRepository.get(Coins.ConfigKey.Bech32), bech32.toWords([...child.identifier])),
+			address: bech32.encode(
+				this.configRepository.get(Coins.ConfigKey.Bech32),
+				bech32.toWords([...child.identifier]),
+			),
 			path,
 			type: "bip44",
 		};

--- a/packages/atom/source/address.service.ts
+++ b/packages/atom/source/address.service.ts
@@ -1,5 +1,5 @@
-import { Coins, IoC, Services } from "@payvo/sdk";
-import { BIP44, bech32 } from "@payvo/sdk-cryptography";
+import { Coins, Services } from "@payvo/sdk";
+import { bech32, BIP44 } from "@payvo/sdk-cryptography";
 
 export class AddressService extends Services.AbstractAddressService {
 	public override async fromMnemonic(
@@ -12,7 +12,7 @@ export class AddressService extends Services.AbstractAddressService {
 		});
 
 		return {
-			address: bech32.encode(this.configRepository.get(Coins.ConfigKey.Bech32), bech32.toWords(child.identifier)),
+			address: bech32.encode(this.configRepository.get(Coins.ConfigKey.Bech32), bech32.toWords([...child.identifier])),
 			path,
 			type: "bip44",
 		};

--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -22,9 +22,8 @@
 	},
 	"dependencies": {
 		"@noble/hashes": "^0.4.1",
-		"base-x": "^3.0.9",
+		"@noble/secp256k1": "^1.3.3",
 		"bcryptjs": "^2.4.3",
-		"bech32": "^2.0.0",
 		"bip38": "^3.1.1",
 		"bip39": "^3.0.4",
 		"bn.js": "^5.2.0",
@@ -32,6 +31,7 @@
 		"create-xpub": "^2.1.0",
 		"elliptic": "^6.5.4",
 		"hdkey": "^2.0.1",
+		"micro-base": "^0.10.0",
 		"node-forge": "^0.10.0",
 		"secp256k1": "^4.0.2",
 		"string-crypto": "^2.0.2",

--- a/packages/cryptography/source/base58-check.test.ts
+++ b/packages/cryptography/source/base58-check.test.ts
@@ -2,7 +2,7 @@ import { describe } from "@payvo/sdk-test";
 
 import { Base58Check } from "./base58-check";
 
-describe("Base58Check", ({ assert, it, nock, loader }) => {
+describe("Base58Check", ({ assert, it }) => {
 	it("should encode the given value", () => {
 		assert.type(Base58Check.encode("Hello"), "string");
 		assert.type(Base58Check.encode(Buffer.from("Hello")), "string");

--- a/packages/cryptography/source/base58-check.ts
+++ b/packages/cryptography/source/base58-check.ts
@@ -23,40 +23,15 @@ const decodeRaw = (buffer: Buffer): Buffer | undefined => {
 	return payload;
 };
 
-/**
- * Implements all functionality that is required to work with the Base58
- * binary-to-text encoding scheme as defined by the specifications.
- *
- * @see {@link https://learnmeabitcoin.com/technical/base58}
- *
- * @export
- * @class Base58Check
- */
 export class Base58Check {
-	/**
-	 * Encodes a string in compliance with the Base58 encoding scheme.
-	 *
-	 * @static
-	 * @param {(string | Buffer)} value
-	 * @returns {string}
-	 * @memberof Base58Check
-	 */
 	public static encode(payload: string | Buffer): string {
 		payload = normalise(payload);
 
 		return Base58.encode(Buffer.concat([payload, normaliseSHA256(payload)], payload.length + 4));
 	}
 
-	/**
-	 * Decodes a string in compliance with the Base58 encoding scheme.
-	 *
-	 * @static
-	 * @param {string} value
-	 * @returns {Buffer}
-	 * @memberof Base58Check
-	 */
 	public static decode(value: string): Buffer {
-		const payload = decodeRaw(Base58.decode(value));
+		const payload = decodeRaw(Buffer.from(Base58.decode(value)));
 
 		if (!payload) {
 			throw new Error("Invalid checksum");

--- a/packages/cryptography/source/base58.test.ts
+++ b/packages/cryptography/source/base58.test.ts
@@ -2,14 +2,14 @@ import { describe } from "@payvo/sdk-test";
 
 import { Base58 } from "./base58";
 
-describe("Base58", ({ assert, it, nock, loader }) => {
+describe("Base58", ({ assert, it }) => {
 	it("should encode the given value", () => {
 		assert.type(Base58.encode("Hello"), "string");
 		assert.type(Base58.encode(Buffer.from("Hello")), "string");
 	});
 
 	it("should decode the given value", () => {
-		assert.is(Base58.decode(Base58.encode("Hello")).toString(), "Hello");
+		assert.is(Base58.decode(Base58.encode("Hello")).toString(), "72,101,108,108,111");
 	});
 
 	it("should validate the given value", () => {

--- a/packages/cryptography/source/base58.ts
+++ b/packages/cryptography/source/base58.ts
@@ -1,59 +1,19 @@
-import basex from "base-x";
+import { base58 } from "micro-base";
 
 const normalise = (value: string | Buffer): Buffer => (value instanceof Buffer ? value : Buffer.from(value));
 
-const BASE58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-
-/**
- * Implements all functionality that is required to work with the Base58
- * binary-to-text encoding scheme as defined by the specifications.
- *
- * @see {@link https://learnmeabitcoin.com/technical/base58}
- *
- * @export
- * @class Base58
- */
 export class Base58 {
-	/**
-	 * Encodes a string in compliance with the Base58 encoding scheme.
-	 *
-	 * @static
-	 * @param {(string | Buffer)} value
-	 * @returns {string}
-	 * @memberof Base58
-	 */
 	public static encode(value: string | Buffer): string {
-		return basex(BASE58).encode(normalise(value));
+		return base58.encode(normalise(value));
 	}
 
-	/**
-	 * Decodes a string in compliance with the Base58 encoding scheme.
-	 *
-	 * @static
-	 * @param {string} value
-	 * @returns {Buffer}
-	 * @memberof Base58
-	 */
-	public static decode(value: string): Buffer {
-		return basex(BASE58).decode(value);
+	public static decode(value: string): Uint8Array {
+		return base58.decode(value);
 	}
 
-	/**
-	 * Validates that the given value has been encoded in compliance with
-	 * the Base58 encoding scheme to ensure that decoding it is possible.
-	 *
-	 * @remarks
-	 * This method should be called before attemtping to decode a value
-	 * to avoid any unhandled or unexpected exceptions.
-	 *
-	 * @static
-	 * @param {string} value
-	 * @returns {boolean}
-	 * @memberof Base58
-	 */
 	public static validate(value: string): boolean {
 		try {
-			basex(BASE58).decode(value);
+			base58.decode(value);
 
 			return true;
 		} catch {

--- a/packages/cryptography/source/bech32.ts
+++ b/packages/cryptography/source/bech32.ts
@@ -1,16 +1,16 @@
-import { bech32 as base, Decoded } from "bech32";
+import { bech32 as base, Bech32Decoded } from "micro-base";
 
 class Bech32 {
-	public encode(prefix: string, words: ArrayLike<number>): string {
+	public encode(prefix: string, words: number[]): string {
 		return base.encode(prefix, words);
 	}
 
-	public decode(value: string, limit?: number | undefined): Decoded {
+	public decode(value: string, limit?: number | undefined): Bech32Decoded {
 		return base.decode(value, limit);
 	}
 
-	public toWords(bytes: ArrayLike<number>): number[] {
-		return base.toWords(bytes);
+	public toWords(bytes: number[]): number[] {
+		return base.toWords(new Uint8Array(bytes));
 	}
 }
 

--- a/packages/trx/source/address.service.ts
+++ b/packages/trx/source/address.service.ts
@@ -13,15 +13,15 @@ export class AddressService extends Services.AbstractAddressService {
 		});
 
 		return {
-			type: "bip44",
 			address: TronWeb.address.fromPrivateKey(child.privateKey!.toString("hex")),
 			path,
+			type: "bip44",
 		};
 	}
 
 	public override async validate(address: string): Promise<boolean> {
 		try {
-			const decoded: Buffer = Base58.decode(address);
+			const decoded: Buffer = Buffer.from(Base58.decode(address));
 			const offset: number = decoded.length - 4;
 			const expected: Buffer = decoded.slice(offset);
 			const actual: Buffer = Hash.sha256(Hash.sha256(Buffer.from(decoded.slice(0, offset)))).slice(0, 4);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,7 @@ importers:
   packages/cryptography:
     specifiers:
       '@noble/hashes': ^0.4.1
+      '@noble/secp256k1': ^1.3.3
       '@payvo/sdk-test': workspace:*
       '@types/bcryptjs': 2.4.2
       '@types/bip38': 2.0.1
@@ -241,9 +242,7 @@ importers:
       '@types/node-forge': 0.10.10
       '@types/uuid': ^8.3.3
       '@types/wif': ^2.0.2
-      base-x: ^3.0.9
       bcryptjs: ^2.4.3
-      bech32: ^2.0.0
       bip38: ^3.1.1
       bip39: ^3.0.4
       bn.js: ^5.2.0
@@ -251,6 +250,7 @@ importers:
       create-xpub: ^2.1.0
       elliptic: ^6.5.4
       hdkey: ^2.0.1
+      micro-base: ^0.10.0
       node-forge: ^0.10.0
       secp256k1: ^4.0.2
       string-crypto: ^2.0.2
@@ -259,9 +259,8 @@ importers:
       wif: ^2.0.6
     dependencies:
       '@noble/hashes': 0.4.1
-      base-x: 3.0.9
+      '@noble/secp256k1': 1.3.3
       bcryptjs: 2.4.3
-      bech32: 2.0.0
       bip38: 3.1.1
       bip39: 3.0.4
       bn.js: 5.2.0
@@ -269,6 +268,7 @@ importers:
       create-xpub: 2.1.0
       elliptic: 6.5.4
       hdkey: 2.0.1
+      micro-base: 0.10.0
       node-forge: 0.10.0
       secp256k1: 4.0.2
       string-crypto: 2.0.2
@@ -1858,6 +1858,10 @@ packages:
 
   /@noble/hashes/0.4.1:
     resolution: {integrity: sha512-Qxy9mZoDf5SyFrQ8hpWHeMZ2Scmb9BAz/lt23sKdr/QHnACW9dD6S+/WVJHd3R/BPoNHcUYWXoXXe74cxSEYoA==}
+    dev: false
+
+  /@noble/secp256k1/1.3.3:
+    resolution: {integrity: sha512-uzKQA9AzoypXGQusSQahpZbNYYnzZblOgr4AjNjI9s3cGy15V+exxmEnjcC6L/slVKMR30NC+srp00Ch6Pm2hg==}
     dev: false
 
   /@nodelib/fs.scandir/2.1.5:
@@ -7649,6 +7653,10 @@ packages:
   /methods/1.1.2:
     resolution: {integrity: sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /micro-base/0.10.0:
+    resolution: {integrity: sha512-huKVznyEDZVO7pcYoVZMBR6prkxzkJSTT96T2tyHY1Wk3Sywcpb7NwxHAwKf/fmfqsdFuY2rDRR3UYkY6Uh9LQ==}
     dev: false
 
   /micro-base/0.9.0:


### PR DESCRIPTION
Replaces `bech32` and `base-x` with https://github.com/paulmillr/micro-base which has 0 dependencies and is actively maintained.