### PR TITLE
fix(ark): validate address based on network configuration

### DIFF
--- a/packages/ark/source/address.service.ts
+++ b/packages/ark/source/address.service.ts
@@ -79,6 +79,6 @@ export class AddressService extends Services.AbstractAddressService {
 	}
 
 	public override async validate(address: string): Promise<boolean> {
-		return BaseAddress.validate(address);
+		return BaseAddress.validate(address, this.#config.network);
 	}
 }

--- a/packages/ark/source/crypto/identities/address.ts
+++ b/packages/ark/source/crypto/identities/address.ts
@@ -51,9 +51,9 @@ export class Address {
 		return result;
 	}
 
-	public static validate(address: string): boolean {
+	public static validate(address: string, network?: Network): boolean {
 		try {
-			return Base58Check.decode(address)[0] === getPubKeyHash();
+			return Base58Check.decode(address)[0] === getPubKeyHash(network);
 		} catch {
 			return false;
 		}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

[#752](https://github.com/PayvoHQ/wallet/issues/752)
Return network selection on address validation

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [x] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
