### PR TITLE
chore(ark): disable vendorfields on BIND networks

### DIFF
--- a/packages/ark/source/networks/bind.mainnet.ts
+++ b/packages/ark/source/networks/bind.mainnet.ts
@@ -62,6 +62,7 @@ const network: Networks.NetworkManifest = {
 			ticker: "BIND",
 			type: "static",
 		},
+		memo: false,
 		multiPaymentRecipients: 128,
 	},
 	type: "live",

--- a/packages/ark/source/networks/bind.testnet.ts
+++ b/packages/ark/source/networks/bind.testnet.ts
@@ -62,6 +62,7 @@ const network: Networks.NetworkManifest = {
 			ticker: "TBIND",
 			type: "static",
 		},
+		memo: false,
 	},
 	type: "test",
 };


### PR DESCRIPTION
See https://github.com/PayvoHQ/wallet/issues/878.