### PR TITLE
fix(ark): reliable way to calculate multisign fees

### DIFF
--- a/packages/ark/source/fee.service.test.ts
+++ b/packages/ark/source/fee.service.test.ts
@@ -146,7 +146,7 @@ describe("FeeService", async ({ assert, nock, it, loader }) => {
 			}),
 		);
 
-		const b = await (await createService(FeeService, "ark.devnet")).calculate({ type: 1 });
+		const b = await (await createService(FeeService, "ark.devnet")).calculate({ type: 1, data: () => ({}) });
 
 		assert.is(a.toHuman(), 50); // Signatures + Base 5
 		assert.is(b.toHuman(), 0);

--- a/packages/ark/source/fee.service.ts
+++ b/packages/ark/source/fee.service.ts
@@ -27,7 +27,7 @@ export class FeeService extends Services.AbstractFeeService {
 	): Promise<BigNumber> {
 		const { multiSignature } = await this.all();
 
-		if (transaction.constructor?.name === "SignedTransactionData") {
+		if (Array.isArray(transaction.data()?.asset?.multiSignature?.publicKeys)) {
 			return multiSignature.static.times(transaction.data().asset.multiSignature.publicKeys.length + 1);
 		}
 


### PR DESCRIPTION
Closes https://github.com/PayvoHQ/wallet/issues/859 (once released and updated on DW)

### Context:

On the desktop wallet, [we use a stub transaction to calculate the multi-signature fees](https://github.com/PayvoHQ/wallet/blob/master/src/app/hooks/use-fees.ts#L84). The problem is that the SDK checks for the classname to return the proper values and since the transaction object is not a regular transaction it doesn't have a classname that makes the condition false and returns zero (which and the end causes the referred issue)

Plus, and is just an observation since wasn't able to find an easy way to test) I think that checking for the classname wouldn't work even if we used a regular transaction object since the constructor's names are usually updated to names like `a4` once compiled.

In summary, checking for the classname is not very reliable and is causing issues so I updated the function to check for the needed properties which think should fix all the problems but may need a review from someone more familiarized with the different use cases for this method cc @faustbrian .
