### PR TITLE
fix: profile not persisting randomly

### DIFF
--- a/packages/profiles/source/environment.test.ts
+++ b/packages/profiles/source/environment.test.ts
@@ -1,10 +1,10 @@
-import { resolve } from "path";
 import { ARK } from "@payvo/sdk-ark";
 import { BTC } from "@payvo/sdk-btc";
 import { ETH } from "@payvo/sdk-eth";
 import { Request } from "@payvo/sdk-fetch";
 import { describe } from "@payvo/sdk-test";
 import fs from "fs-extra";
+import { resolve } from "path";
 
 import storageData from "../test/fixtures/env-storage.json";
 import { identity } from "../test/fixtures/identity";
@@ -393,7 +393,12 @@ describe("Environment", ({ beforeEach, it, assert, nock, loader }) => {
 
 		const profile = await context.subject.profiles().create("John Doe");
 		profile.auth().setPassword("password");
-		assert.not.throws(() => context.subject.persist());
+
+		assert.true(profile.status().isDirty());
+
+		await context.subject.persist();
+
+		assert.false(profile.status().isDirty());
 	});
 
 	it("should flush all bindings", async (context) => {

--- a/packages/profiles/source/environment.ts
+++ b/packages/profiles/source/environment.ts
@@ -92,7 +92,7 @@ export class Environment {
 		const storage: Storage = container.get<Storage>(Identifiers.Storage);
 
 		for (const profile of this.profiles().values()) {
-			this.profiles().persist(profile);
+			await this.profiles().persist(profile);
 		}
 
 		await storage.set("profiles", this.profiles().toObject());


### PR DESCRIPTION
Adds a missing `await` to the profile persist method which is the cause of the bug described here https://github.com/PayvoHQ/wallet/issues/897 and others, for example, I noticed that sometimes when you update your name in the settings is not stored when you refresh 