### PR TITLE
refactor: accept payload as string in `LedgerService#signMessage`

### DIFF
--- a/packages/ark/source/ledger.service.test.ts
+++ b/packages/ark/source/ledger.service.test.ts
@@ -73,7 +73,7 @@ describe("LedgerService", async ({ assert, it, nock, loader }) => {
 		const ark = await createMockService(ledger.message.schnorr.record);
 
 		assert.is(
-			await ark.signMessage(ledger.bip44.path, Buffer.from(ledger.message.schnorr.payload, "hex")),
+			await ark.signMessage(ledger.bip44.path, Buffer.from(ledger.message.schnorr.payload, "hex").toString()),
 			ledger.message.schnorr.result,
 		);
 	});

--- a/packages/ark/source/ledger.service.ts
+++ b/packages/ark/source/ledger.service.ts
@@ -1,6 +1,7 @@
 import { ARKTransport } from "@arkecosystem/ledger-transport";
 import { Contracts, IoC, Services } from "@payvo/sdk";
 import { BIP44, HDKey } from "@payvo/sdk-cryptography";
+import { Buffer } from "buffer"
 
 import { chunk, createRange, formatLedgerDerivationPath } from "./ledger.service.helpers.js";
 
@@ -48,8 +49,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 		return this.#transport.signTransactionWithSchnorr(path, payload);
 	}
 
-	public override async signMessage(path: string, payload: Buffer): Promise<string> {
-		return this.#transport.signMessageWithSchnorr(path, payload);
+	public override async signMessage(path: string, payload: string): Promise<string> {
+		return this.#transport.signMessageWithSchnorr(path, Buffer.from(payload));
 	}
 
 	public override async scan(options?: {

--- a/packages/ark/source/ledger.service.ts
+++ b/packages/ark/source/ledger.service.ts
@@ -1,7 +1,7 @@
 import { ARKTransport } from "@arkecosystem/ledger-transport";
 import { Contracts, IoC, Services } from "@payvo/sdk";
 import { BIP44, HDKey } from "@payvo/sdk-cryptography";
-import { Buffer } from "buffer"
+import { Buffer } from "buffer";
 
 import { chunk, createRange, formatLedgerDerivationPath } from "./ledger.service.helpers.js";
 

--- a/packages/atom/source/ledger.service.test.ts
+++ b/packages/atom/source/ledger.service.test.ts
@@ -72,6 +72,6 @@ describe("signMessage", ({ assert, it, nock, loader }) => {
 	it("should fail with a 'NotImplemented' error", async () => {
 		const subject = await createMockService("");
 
-		await assert.rejects(() => subject.signMessage("", Buffer.alloc(0)));
+		await assert.rejects(() => subject.signMessage("", ""));
 	});
 });

--- a/packages/btc/source/ledger.service.test.ts
+++ b/packages/btc/source/ledger.service.test.ts
@@ -73,7 +73,7 @@ describe("LedgerService", async ({ assert, it }) => {
 		const subject = await createMockService(ledger.message.record);
 
 		assert.is(
-			await subject.signMessage(ledger.bip44.path, Buffer.from(ledger.message.payload, "utf-8")),
+			await subject.signMessage(ledger.bip44.path, ledger.message.payload),
 			ledger.message.result,
 		);
 	});

--- a/packages/btc/source/ledger.service.test.ts
+++ b/packages/btc/source/ledger.service.test.ts
@@ -72,9 +72,6 @@ describe("LedgerService", async ({ assert, it }) => {
 	it("signMessage", async () => {
 		const subject = await createMockService(ledger.message.record);
 
-		assert.is(
-			await subject.signMessage(ledger.bip44.path, ledger.message.payload),
-			ledger.message.result,
-		);
+		assert.is(await subject.signMessage(ledger.bip44.path, ledger.message.payload), ledger.message.result);
 	});
 });

--- a/packages/btc/source/ledger.service.ts
+++ b/packages/btc/source/ledger.service.ts
@@ -62,8 +62,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 		});
 	}
 
-	public override async signMessage(path: string, payload: Buffer): Promise<string> {
-		const signature = await this.#transport.signMessageNew(path, convertBuffer(payload));
+	public override async signMessage(path: string, payload: string): Promise<string> {
+		const signature = await this.#transport.signMessageNew(path, convertBuffer(Buffer.from(payload)));
 
 		return JSON.stringify(signature);
 	}

--- a/packages/dot/source/ledger.service.test.ts
+++ b/packages/dot/source/ledger.service.test.ts
@@ -75,6 +75,6 @@ describe("signMessage", ({ it, assert }) => {
 	it("should fail to generate an output from a message", async () => {
 		const polkadot = await createMockService("");
 
-		await assert.rejects(() => polkadot.signMessage("", Buffer.alloc(0)));
+		await assert.rejects(() => polkadot.signMessage("", ""));
 	});
 });

--- a/packages/eos/source/ledger.service.test.ts
+++ b/packages/eos/source/ledger.service.test.ts
@@ -80,6 +80,6 @@ describe("signMessage", ({ it, assert }) => {
 	it("should fail with a 'NotImplemented' error", async () => {
 		const subject = await createMockService("");
 
-		await assert.rejects(() => subject.signMessage("", Buffer.alloc(0)));
+		await assert.rejects(() => subject.signMessage("", ""));
 	});
 });

--- a/packages/eth/source/ledger.service.test.ts
+++ b/packages/eth/source/ledger.service.test.ts
@@ -71,7 +71,7 @@ describe("signMessage", ({ it, assert }) => {
 	it("should pass with a signature", async () => {
 		const trx = await createMockService(ledger.message.record);
 
-		const result = await trx.signMessage(ledger.bip44.path, Buffer.from(ledger.message.payload, "hex"));
+		const result = await trx.signMessage(ledger.bip44.path, Buffer.from(ledger.message.payload, "hex").toString());
 
 		assert.equal(JSON.parse(result), ledger.message.result);
 	});

--- a/packages/eth/source/ledger.service.ts
+++ b/packages/eth/source/ledger.service.ts
@@ -1,5 +1,6 @@
 import { IoC, Services } from "@payvo/sdk";
 import Ethereum from "@ledgerhq/hw-app-eth";
+import { Buffer } from "buffer"
 
 export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;
@@ -30,7 +31,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 		return JSON.stringify(await this.#transport.signTransaction(path, payload.toString("hex")));
 	}
 
-	public override async signMessage(path: string, payload: Buffer): Promise<string> {
-		return JSON.stringify(await this.#transport.signPersonalMessage(path, payload.toString("hex")));
+	public override async signMessage(path: string, payload: string): Promise<string> {
+		return JSON.stringify(await this.#transport.signPersonalMessage(path, Buffer.from(payload).toString("hex")));
 	}
 }

--- a/packages/eth/source/ledger.service.ts
+++ b/packages/eth/source/ledger.service.ts
@@ -1,6 +1,6 @@
 import { IoC, Services } from "@payvo/sdk";
 import Ethereum from "@ledgerhq/hw-app-eth";
-import { Buffer } from "buffer"
+import { Buffer } from "buffer";
 
 export class LedgerService extends Services.AbstractLedgerService {
 	#ledger: Services.LedgerTransport;

--- a/packages/lsk/source/ledger.service.test.ts
+++ b/packages/lsk/source/ledger.service.test.ts
@@ -96,7 +96,7 @@ describe("signMessage", ({ it, assert }) => {
 		const lsk = await createMockService(ledger.message.record);
 
 		assert.is(
-			await lsk.signMessage(ledger.bip44.path, Buffer.from(ledger.message.payload, "hex")),
+			await lsk.signMessage(ledger.bip44.path, Buffer.from(ledger.message.payload, "hex").toString()),
 			ledger.message.result,
 		);
 	});

--- a/packages/lsk/source/ledger.service.ts
+++ b/packages/lsk/source/ledger.service.ts
@@ -1,7 +1,7 @@
 import { getLegacyAddressFromPublicKey, getLisk32AddressFromPublicKey } from "@liskhq/lisk-cryptography";
 import { Contracts, IoC, Services } from "@payvo/sdk";
 import { BIP44 } from "@payvo/sdk-cryptography";
-import { Buffer } from "buffer"
+import { Buffer } from "buffer";
 
 import { LedgerTransport } from "./ledger/transport.js";
 

--- a/packages/lsk/source/ledger.service.ts
+++ b/packages/lsk/source/ledger.service.ts
@@ -44,7 +44,7 @@ export class LedgerService extends Services.AbstractLedgerService {
 	}
 
 	public override async signMessage(path: string, payload: string): Promise<string> {
-		const signature: Buffer = await this.#transport.signMSG(this.#getLedgerAccount(path), Buffer.from(payload));
+		const signature: Buffer = await this.#transport.signMSG(this.#getLedgerAccount(path), payload);
 
 		return signature.slice(0, 64).toString("hex");
 	}

--- a/packages/lsk/source/ledger.service.ts
+++ b/packages/lsk/source/ledger.service.ts
@@ -1,6 +1,7 @@
 import { getLegacyAddressFromPublicKey, getLisk32AddressFromPublicKey } from "@liskhq/lisk-cryptography";
 import { Contracts, IoC, Services } from "@payvo/sdk";
 import { BIP44 } from "@payvo/sdk-cryptography";
+import { Buffer } from "buffer"
 
 import { LedgerTransport } from "./ledger/transport.js";
 
@@ -42,8 +43,8 @@ export class LedgerService extends Services.AbstractLedgerService {
 		return signature.toString("hex");
 	}
 
-	public override async signMessage(path: string, payload: Buffer): Promise<string> {
-		const signature: Buffer = await this.#transport.signMSG(this.#getLedgerAccount(path), payload);
+	public override async signMessage(path: string, payload: string): Promise<string> {
+		const signature: Buffer = await this.#transport.signMSG(this.#getLedgerAccount(path), Buffer.from(payload));
 
 		return signature.slice(0, 64).toString("hex");
 	}

--- a/packages/neo/source/ledger.service.test.ts
+++ b/packages/neo/source/ledger.service.test.ts
@@ -85,6 +85,6 @@ describe("signMessage", ({ it, assert }) => {
 	it("should pass with an ecdsa signature", async () => {
 		const subject = await createMockService("");
 
-		await assert.rejects(() => subject.signMessage("", Buffer.alloc(0)));
+		await assert.rejects(() => subject.signMessage("", ""));
 	});
 });

--- a/packages/sdk/source/ledger.contract.ts
+++ b/packages/sdk/source/ledger.contract.ts
@@ -18,7 +18,7 @@ export interface LedgerService {
 
 	signTransaction(path: string, payload: Buffer): Promise<string>;
 
-	signMessage(path: string, payload: Buffer): Promise<string>;
+	signMessage(path: string, payload: string): Promise<string>;
 
 	scan(options?: {
 		useLegacy: boolean;

--- a/packages/sdk/source/ledger.service.ts
+++ b/packages/sdk/source/ledger.service.ts
@@ -48,7 +48,7 @@ export class AbstractLedgerService implements LedgerService {
 		throw new NotImplemented(this.constructor.name, this.signTransaction.name);
 	}
 
-	public async signMessage(path: string, payload: Buffer): Promise<string> {
+	public async signMessage(path: string, payload: string): Promise<string> {
 		throw new NotImplemented(this.constructor.name, this.signMessage.name);
 	}
 

--- a/packages/trx/source/ledger.service.test.ts
+++ b/packages/trx/source/ledger.service.test.ts
@@ -64,6 +64,6 @@ describe("LedgerService", async ({ it, assert }) => {
 	it("#signMessage", async () => {
 		const trx = await createMockService("");
 
-		await assert.rejects(() => trx.signMessage("", Buffer.alloc(0)));
+		await assert.rejects(() => trx.signMessage("", ""));
 	});
 });

--- a/packages/xlm/source/ledger.service.test.ts
+++ b/packages/xlm/source/ledger.service.test.ts
@@ -72,6 +72,6 @@ describe("signMessage", ({ it, assert }) => {
 	it("should fail with a 'NotImplemented' error", async () => {
 		const trx = await createMockService("");
 
-		await assert.rejects(() => trx.signMessage("", Buffer.alloc(0)));
+		await assert.rejects(() => trx.signMessage("", ""));
 	});
 });

--- a/packages/xrp/source/ledger.service.test.ts
+++ b/packages/xrp/source/ledger.service.test.ts
@@ -72,6 +72,6 @@ describe("signMessage", ({ it, assert }) => {
 	it("should fail with a 'NotImplemented' error", async () => {
 		const xrp = await createMockService("");
 
-		await assert.rejects(() => xrp.signMessage("", Buffer.alloc(0)));
+		await assert.rejects(() => xrp.signMessage("", ""));
 	});
 });


### PR DESCRIPTION
Allows consumers to provide a utf8 string as message input instead of Buffer, when signing messages with ledger wallet.

Consumers won't be required to have Buffer dependency in order to sign a message.  See https://github.com/PayvoHQ/wallet/pull/957
